### PR TITLE
TSA enhancement

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -1451,6 +1451,7 @@ void DbInterface::handleSwssNotification()
 
     swss::Select swssSelect;
     swssSelect.addSelectable(&configDbMuxLinkmgrTable);
+    swssSelect.addSelectable(&configDbBgpDeviceGlobalTable);
     swssSelect.addSelectable(&configDbMuxTable);
     swssSelect.addSelectable(&appDbPortTable);
     swssSelect.addSelectable(&appDbMuxResponseTable);

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -806,6 +806,24 @@ private:
     */
     void handleDefaultRouteStateNotification(swss::SubscriberStateTable &statedbRouteTable);
 
+    /**
+     * @method handleBgpDeviceGlobal
+     * 
+     * @brief handle tsa_enable notification from BGP Device Global table 
+     * 
+     * @return none
+     */
+    void handleBgpDeviceGlobal(swss::SubscriberStateTable &configDbBgpDeviceGlobalTable);
+
+    /**
+     * @method processTsaEnableNotification
+     * 
+     * @brief process Tsa Enable Notification
+     * 
+     * @return none
+     */
+    void processTsaEnableNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
+
 private:
     static std::vector<std::string> mMuxState;
     static std::vector<std::string> mMuxLinkmgrState;

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -575,4 +575,21 @@ void MuxManager::handleWarmRestartReconciliationTimeout(const boost::system::err
     mDbInterfacePtr->setWarmStartStateReconciled();
 }
 
+//
+// ---> handleTsaEnableNotification
+//
+// handle TSA Enable Notification
+//
+void MuxManager::handleTsaEnableNotification(bool enable)
+{
+    if (enable) {
+        PortMapIterator portMapIterator = mPortMap.begin();
+
+        while (portMapIterator != mPortMap.end()) {
+            portMapIterator->second->handleTsaEnable();
+            portMapIterator ++;
+        }
+    }
+}
+
 } /* namespace mux */

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -582,13 +582,11 @@ void MuxManager::handleWarmRestartReconciliationTimeout(const boost::system::err
 //
 void MuxManager::handleTsaEnableNotification(bool enable)
 {
-    if (enable) {
-        PortMapIterator portMapIterator = mPortMap.begin();
+    PortMapIterator portMapIterator = mPortMap.begin();
 
-        while (portMapIterator != mPortMap.end()) {
-            portMapIterator->second->handleTsaEnable();
-            portMapIterator ++;
-        }
+    while (portMapIterator != mPortMap.end()) {
+        portMapIterator->second->handleTsaEnable(enable);
+        portMapIterator ++;
     }
 }
 

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -452,6 +452,15 @@ public:
      */
     void updateWarmRestartReconciliationCount(int increment);
 
+    /**
+     * @method handleTsaEnableNotification
+     * 
+     * @brief handle TSA Enable Notification
+     * 
+     * @return none
+     */
+    void handleTsaEnableNotification(bool enable);
+
 private:
     /**
     *@method getMuxPortCableType

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -417,4 +417,21 @@ void MuxPort::warmRestartReconciliation()
     }
 }
 
+//
+// ---> handleTsaEnable();
+//
+// handle TSA Enable 
+//
+void MuxPort::handleTsaEnable()
+{
+    MUXLOGWARNING(boost::format("port: %s, configuring to Standby due to tsa_enable notification from CONFIG DB. ") % mMuxPortConfig.getPortName());
+
+    boost::asio::io_service &ioService = mStrand.context();
+    ioService.post(mStrand.wrap(boost::bind(
+        &link_manager::LinkManagerStateMachine::handleMuxConfigNotification,
+        &mLinkManagerStateMachine,
+        common::MuxPortConfig::Mode::Standby
+    )));
+}
+
 } /* namespace mux */

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -428,8 +428,8 @@ void MuxPort::handleTsaEnable()
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
-        &link_manager::LinkManagerStateMachine::handleMuxConfigNotification,
-        &mLinkManagerStateMachine,
+        &link_manager::LinkManagerStateMachineBase::handleMuxConfigNotification,
+        mLinkManagerStateMachinePtr.get(),
         common::MuxPortConfig::Mode::Standby
     )));
 }

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -422,15 +422,20 @@ void MuxPort::warmRestartReconciliation()
 //
 // handle TSA Enable 
 //
-void MuxPort::handleTsaEnable()
+void MuxPort::handleTsaEnable(bool enable)
 {
-    MUXLOGWARNING(boost::format("port: %s, configuring to Standby due to tsa_enable notification from CONFIG DB. ") % mMuxPortConfig.getPortName());
+    MUXLOGWARNING(boost::format("port: %s, configuring mux mode due to tsa_enable notification from CONFIG DB. ") % mMuxPortConfig.getPortName());
+
+    common::MuxPortConfig::Mode mode = common::MuxPortConfig::Auto;
+    if (enable) {
+        mode = common::MuxPortConfig::Standby;
+    }
 
     boost::asio::io_service &ioService = mStrand.context();
     ioService.post(mStrand.wrap(boost::bind(
         &link_manager::LinkManagerStateMachineBase::handleMuxConfigNotification,
         mLinkManagerStateMachinePtr.get(),
-        common::MuxPortConfig::Mode::Standby
+        mode
     )));
 }
 

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -395,6 +395,15 @@ public:
      */
     void warmRestartReconciliation();
 
+    /**
+     * @method handleTsaEnable
+     * 
+     * @brief handle TSA Enable event 
+     * 
+     * @return none
+     */
+    void handleTsaEnable();
+
 protected:
     friend class test::MuxManagerTest;
     friend class test::FakeMuxPort;

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -402,7 +402,7 @@ public:
      * 
      * @return none
      */
-    void handleTsaEnable();
+    void handleTsaEnable(bool enable);
 
 protected:
     friend class test::MuxManagerTest;

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -174,6 +174,11 @@ void MuxManagerTest::processMuxPortConfigNotifiction(std::deque<swss::KeyOpField
     mDbInterfacePtr->processMuxPortConfigNotifiction(entries);
 }
 
+void MuxManagerTest::processTsaEnableNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries)
+{
+    mDbInterfacePtr->processTsaEnableNotification(entries);
+}
+
 link_manager::LinkManagerStateMachineBase::CompositeState MuxManagerTest::getCompositeStateMachineState(std::string port)
 {
     std::shared_ptr<mux::MuxPort> muxPortPtr = mMuxManagerPtr->mPortMap[port];
@@ -938,6 +943,19 @@ TEST_F(MuxManagerTest, WarmRestartTimeout)
 
     runIoService(1);
     EXPECT_EQ(mDbInterfacePtr->mSetWarmStartStateReconciledInvokeCount, 1);
+}
+
+TEST_F(MuxManagerTest, TsaEnable)
+{
+    createPort("Ethernet0");
+
+    std::deque<swss::KeyOpFieldsValuesTuple> entries = {
+        {"BGP_DEVICE_GLOBAL", "SET", {{"tsa_enabled", "true"}}},
+    };
+    processTsaEnableNotification(entries);
+    runIoService();
+
+    EXPECT_TRUE(getMode("Ethernet0") == common::MuxPortConfig::Mode::Standby);
 }
 
 } /* namespace test */

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -956,6 +956,14 @@ TEST_F(MuxManagerTest, TsaEnable)
     runIoService();
 
     EXPECT_TRUE(getMode("Ethernet0") == common::MuxPortConfig::Mode::Standby);
+
+    std::deque<swss::KeyOpFieldsValuesTuple> disable_entries = {
+        {"BGP_DEVICE_GLOBAL", "SET", {{"tsa_enabled", "false"}}},
+    };
+    processTsaEnableNotification(disable_entries);
+    runIoService();
+
+    EXPECT_TRUE(getMode("Ethernet0") == common::MuxPortConfig::Mode::Auto);
 }
 
 } /* namespace test */

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -67,6 +67,7 @@ public:
     std::array<uint8_t, ETHER_ADDR_LEN> getVlanMacAddress(std::string port);
     common::MuxPortConfig::PortCableType getPortCableType(const std::string &port);
     void processMuxPortConfigNotifiction(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
+    void processTsaEnableNotification(std::deque<swss::KeyOpFieldsValuesTuple> &entries);
     link_manager::LinkManagerStateMachineBase::CompositeState getCompositeStateMachineState(std::string port);
     void processServerIpAddress(std::vector<swss::KeyOpFieldsValuesTuple> &servers);
     void processSoCIpAddress(std::vector<swss::KeyOpFieldsValuesTuple> &servers);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is an enhancement for TSA. When the CONFIG DB entry below is added, linkmgrd should be set to `standby`. 

```
    "BGP_DEVICE_GLOBAL": {
        "STATE": {
            "tsa_enabled": "false"
        }
    }
```

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
This PR is to enhance TSA logic, to handle the scenario when BGP_DEVICE_GLOBAL configuration is pushed directly without explicitly executing `TSA`.

#### How did you do it?
Make linkmgrd listen CONFIG DB `CFG_BGP_DEVICE_GLOBAL_TABLE_NAME` table, and config mux mode to `standby` once `tsa_enabled == true`.

#### How did you verify/test it?
1. Added unit tests.
2. Tested on dual testbeds with `redis-cli -n 4 hset "BGP_DEVICE_GLOBAL|STATE" tsa_enabled true`, was able to see logs from handlers and `show mux status` switch to `standby`.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->