### PR TITLE
Update the definition of `healthy` label 

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -876,7 +876,9 @@ void ActiveActiveStateMachine::probeMuxState()
 void ActiveActiveStateMachine::updateMuxLinkmgrState()
 {
     Label label = Label::Unhealthy;
-    if (ls(mCompositeState) == link_state::LinkState::Label::Up && ps(mCompositeState) == link_prober::LinkProberState::Label::Active && ms(mCompositeState) == mux_state::MuxState::Label::Active) {
+    if (ls(mCompositeState) == link_state::LinkState::Label::Up &&
+        ps(mCompositeState) == link_prober::LinkProberState::Label::Active &&
+        (mMuxPortConfig.ifEnableDefaultRouteFeature() == false || mDefaultRouteState == DefaultRoute::OK)) {
         label = Label::Healthy;
     }
     setLabel(label);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to update the definition of `healthy` label in active-active set up, to remove the dependency on gRPC healthiness. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
In active-active setup, the state machine does not depend on gRPC server's healthiness any more. Hence we don't want to `show mux status` to print `unhealthy` label when receiving unexpected state notification from gRPC or when gRPC is inaccessible. 

#### How did you do it?
Updated `updateMuxLinkmgrState` method to check link prober, link state & default route only.

#### How did you verify/test it?
Unit tests. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->