### PR TITLE
[Active-Standby]Remove unnecessary `handleMuxWaitTimeout` logs

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -847,7 +847,6 @@ private:
 
     uint32_t mWaitActiveUpCount = 0;
     uint32_t mMuxUnknownBackoffFactor = 1;
-    uint32_t mMuxWaitTimeoutCount = 0;
 
     bool mPendingMuxModeChange = false;
     common::MuxPortConfig::Mode mTargetMuxMode = common::MuxPortConfig::Mode::Auto;

--- a/test/FakeLinkProber.cpp
+++ b/test/FakeLinkProber.cpp
@@ -126,6 +126,19 @@ void FakeLinkProber::sendPeerSwitchCommand()
     mSendPeerSwitchCommand++;
 }
 
+void FakeLinkProber::handleSendSwitchCommand()
+{
+    // inform the composite state machine about command send completion
+    boost::asio::io_service::strand& strand = mLinkProberStateMachine->getStrand();
+    boost::asio::io_service &ioService = strand.context();
+    ioService.post(strand.wrap(boost::bind(
+        static_cast<void (link_prober::LinkProberStateMachineBase::*) (link_prober::SwitchActiveCommandCompleteEvent&)>
+            (&link_prober::LinkProberStateMachineBase::processEvent),
+        mLinkProberStateMachine,
+        link_prober::LinkProberStateMachineBase::getSwitchActiveCommandCompleteEvent()
+    )));
+}
+
 void FakeLinkProber::resetIcmpPacketCounts()
 {
     MUXLOGINFO("");

--- a/test/FakeLinkProber.h
+++ b/test/FakeLinkProber.h
@@ -51,6 +51,7 @@ public:
     void restartTxProbes();
     void decreaseProbeIntervalAfterSwitch(uint32_t switchTime_msec);
     void revertProbeIntervalAfterSwitchComplete();
+    void handleSendSwitchCommand();
 
 
 public:

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -441,6 +441,31 @@ TEST_F(LinkManagerStateMachineTest, MuxAStandbyCliManual)
     VALIDATE_STATE(Standby, Standby, Up);
 }
 
+TEST_F(LinkManagerStateMachineTest, MuxActiveCliStandby)
+{
+    setMuxActive();
+
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSendPeerSwitchCommand, 0);
+    handleMuxConfig("standby");
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSendPeerSwitchCommand, 1);
+
+    mFakeMuxPort.mFakeLinkProber->handleSendSwitchCommand();
+    runIoService(2);
+    VALIDATE_STATE(Wait, Wait, Up);
+
+    // swss notification
+    handleMuxState("standby", 3);
+    VALIDATE_STATE(Wait, Standby, Up);
+
+    // change state to active
+    postLinkProberEvent(link_prober::LinkProberState::Standby, 2);
+    VALIDATE_STATE(Standby, Wait, Up);
+
+    // xcvrd notification
+    handleProbeMuxState("standby", 4);
+    VALIDATE_STATE(Standby, Standby, Up);
+}
+
 TEST_F(LinkManagerStateMachineTest, MuxStandbyCliSwitchOverMuxFirst)
 {
     setMuxStandby();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to  address the overwhelming `handleMuxWaitTimeout` syslog.

sign-off: Jing Zhang zhangjing@microsoft.com 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
1. We saw millions of `handleMuxWaitTimeout` log in 24 hours on a ToR with unhealthy interfaces, which is way too chatty and unnecessary.

#### How did you do it?
1. Log only once when timing out on mux state probing (38.4 seconds). 
 
#### How did you verify/test it?
1. Unit tests. 
1. Tested on cluster device, didn't see the flooding messages any more. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->