### PR TITLE
[active-active] Update `unhealthy` label definition

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -878,6 +878,7 @@ void ActiveActiveStateMachine::updateMuxLinkmgrState()
     Label label = Label::Unhealthy;
     if (ls(mCompositeState) == link_state::LinkState::Label::Up &&
         ps(mCompositeState) == link_prober::LinkProberState::Label::Active &&
+        ms(mCompositeState) != mux_state::MuxState::Label::Standby &&
         (mMuxPortConfig.ifEnableDefaultRouteFeature() == false || mDefaultRouteState == DefaultRoute::OK)) {
         label = Label::Healthy;
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Submitting this PR to stop considering gRPC state `standby` as `healthy`. 

When ToR-A is `healthy`, in upgrade scenario, ToR-B might go ahead with cold reboot. And if ToR-A's gRPC state is `standby` in this case, we will lose northbound traffic. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To avoid unwanted cold reboot in upgrades. 

#### How did you do it?
Stop considering gRPC state `standby` as healthy. 

#### How did you verify/test it?
Unit tests.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->