### PR TITLE
Fix race condition caused by strand `wrap` method

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -70,12 +70,11 @@ void DbInterface::getMuxState(const std::string &portName)
 {
     MUXLOGDEBUG(portName);
 
-    boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(
+    boost::asio::post(mStrand, boost::bind(
         &DbInterface::handleGetMuxState,
         this,
         portName
-    )));
+    ));
 }
 
 //
@@ -87,13 +86,12 @@ void DbInterface::setMuxState(const std::string &portName, mux_state::MuxState::
 {
     MUXLOGDEBUG(boost::format("%s: setting mux to %s") % portName % mMuxState[label]);
 
-    boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(
+    boost::asio::post(mStrand, boost::bind(
         &DbInterface::handleSetMuxState,
         this,
         portName,
         label
-    )));
+    ));
 }
 
 //
@@ -105,13 +103,12 @@ void DbInterface::setPeerMuxState(const std::string &portName, mux_state::MuxSta
 {
     MUXLOGDEBUG(boost::format("%s: setting peer mux to %s") % portName % mMuxState[label]);
 
-    boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(
+    boost::asio::post(mStrand, boost::bind(
         &DbInterface::handleSetPeerMuxState,
         this,
         portName,
         label
-    )));
+    ));
 }
 
 
@@ -124,12 +121,11 @@ void DbInterface::probeMuxState(const std::string &portName)
 {
     MUXLOGDEBUG(portName);
 
-    boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(
+    boost::asio::post(mStrand, boost::bind(
         &DbInterface::handleProbeMuxState,
         this,
         portName
-    )));
+    ));
 }
 
 //
@@ -141,12 +137,11 @@ void DbInterface::probeForwardingState(const std::string &portName)
 {
     MUXLOGDEBUG(portName);
 
-    boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(
+    boost::asio::post(mStrand, boost::bind(
         &DbInterface::handleProbeForwardingState,
         this,
         portName
-    )));
+    ));
 }
 
 //
@@ -158,13 +153,12 @@ void DbInterface::setMuxLinkmgrState(const std::string &portName, link_manager::
 {
     MUXLOGDEBUG(boost::format("%s: setting mux linkmgr to %s") % portName % mMuxLinkmgrState[static_cast<int> (label)]);
 
-    boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(
+    boost::asio::post(mStrand, boost::bind(
         &DbInterface::handleSetMuxLinkmgrState,
         this,
         portName,
         label
-    )));
+    ));
 }
 
 //
@@ -187,15 +181,14 @@ void DbInterface::postMetricsEvent(
         mMuxMetrics[static_cast<int> (metrics)]
     );
 
-    boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(
+    boost::asio::post(mStrand, boost::bind(
         &DbInterface::handlePostMuxMetrics,
         this,
         portName,
         metrics,
         label,
         boost::posix_time::microsec_clock::universal_time()
-    )));
+    ));
 }
 
 // 
@@ -215,14 +208,13 @@ void DbInterface::postLinkProberMetricsEvent(
         mLinkProbeMetrics[static_cast<int> (metrics)]
     );
 
-    boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(
+    boost::asio::post(mStrand, boost::bind(
         &DbInterface::handlePostLinkProberMetrics,
         this,
         portName,
         metrics,
         boost::posix_time::microsec_clock::universal_time()
-    )));
+    ));
 }
 
 //
@@ -244,14 +236,13 @@ void DbInterface::postPckLossRatio(
         expectedPacketCount
     );
 
-    boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(
+    boost::asio::post(mStrand,boost::bind(
         &DbInterface::handlePostPckLossRatio,
         this,
         portName,
         unknownEventCount,
         expectedPacketCount
-    ))); 
+    ));
 }
 
 //
@@ -841,13 +832,12 @@ void DbInterface::setMuxMode(const std::string &portName, const std::string stat
 {
     MUXLOGDEBUG(portName);
 
-    boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(
+    boost::asio::post(mStrand,boost::bind(
         &DbInterface::handleSetMuxMode,
         this,
         portName,
         state
-    )));
+    ));
 }
 
 //

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -141,6 +141,18 @@ public:
     void setMuxState(const std::string &portName, mux_state::MuxState::Label label);
 
     /**
+    *@method handleSetMuxState
+    *
+    *@brief set MUX state in APP DB for orchagent processing
+    *
+    *@param portName (in)   MUX/port name
+    *@param label (in)      label of target state
+    *
+    *@return none
+    */
+    virtual void handleSetMuxState(const std::string portName, mux_state::MuxState::Label label);
+
+    /**
     *@method setPeerMuxState
     *
     *@brief set peer MUX state in APP DB for orchagent processing
@@ -201,6 +213,25 @@ public:
         const std::string &portName,
         link_manager::ActiveStandbyStateMachine::Metrics metrics,
         mux_state::MuxState::Label label
+    );
+
+    /**
+    *@method handlePostMuxMetrics
+    *
+    *@brief set MUX metrics to state db
+    *
+    *@param portName (in)   MUX/port name
+    *@param metrics (in)    metrics data
+    *@param label (in)      label of target state
+    *@param time (in)       current time
+    *
+    *@return none
+    */
+    virtual void handlePostMuxMetrics(
+        const std::string portName,
+        link_manager::ActiveStandbyStateMachine::Metrics metrics,
+        mux_state::MuxState::Label label,
+        boost::posix_time::ptime time
     );
 
     /**
@@ -340,18 +371,6 @@ private:
     void handleGetMuxState(const std::string portName);
 
     /**
-    *@method handleSetMuxState
-    *
-    *@brief set MUX state in APP DB for orchagent processing
-    *
-    *@param portName (in)   MUX/port name
-    *@param label (in)      label of target state
-    *
-    *@return none
-    */
-    virtual void handleSetMuxState(const std::string portName, mux_state::MuxState::Label label);
-
-    /**
     *@method handleSetPeerMuxState
     *
     *@brief set peer MUX state in APP DB for orchagent processing
@@ -396,25 +415,6 @@ private:
     *@return none
     */
     void handleSetMuxLinkmgrState(const std::string portName, link_manager::ActiveStandbyStateMachine::Label label);
-
-    /**
-    *@method handlePostMuxMetrics
-    *
-    *@brief set MUX metrics to state db
-    *
-    *@param portName (in)   MUX/port name
-    *@param metrics (in)    metrics data
-    *@param label (in)      label of target state
-    *@param time (in)       current time
-    *
-    *@return none
-    */
-    virtual void handlePostMuxMetrics(
-        const std::string portName,
-        link_manager::ActiveStandbyStateMachine::Metrics metrics,
-        mux_state::MuxState::Label label,
-        boost::posix_time::ptime time
-    );
 
     /**
      * @method handlePostLinkProberMetrics

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -138,7 +138,7 @@ public:
     *
     *@return none
     */
-    virtual void setMuxState(const std::string &portName, mux_state::MuxState::Label label);
+    void setMuxState(const std::string &portName, mux_state::MuxState::Label label);
 
     /**
     *@method setPeerMuxState
@@ -197,7 +197,7 @@ public:
     *
     *@return none
     */
-    virtual void postMetricsEvent(
+    void postMetricsEvent(
         const std::string &portName,
         link_manager::ActiveStandbyStateMachine::Metrics metrics,
         mux_state::MuxState::Label label
@@ -349,7 +349,7 @@ private:
     *
     *@return none
     */
-    void handleSetMuxState(const std::string portName, mux_state::MuxState::Label label);
+    virtual void handleSetMuxState(const std::string portName, mux_state::MuxState::Label label);
 
     /**
     *@method handleSetPeerMuxState
@@ -409,7 +409,7 @@ private:
     *
     *@return none
     */
-    void handlePostMuxMetrics(
+    virtual void handlePostMuxMetrics(
         const std::string portName,
         link_manager::ActiveStandbyStateMachine::Metrics metrics,
         mux_state::MuxState::Label label,

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -162,7 +162,7 @@ public:
     *
     *@return none
     */
-    virtual void setPeerMuxState(const std::string &portName, mux_state::MuxState::Label label);
+    void setPeerMuxState(const std::string &portName, mux_state::MuxState::Label label);
 
     /**
     *@method probeMuxState
@@ -184,7 +184,7 @@ public:
      * 
      * @return none
      */
-    virtual void probeForwardingState(const std::string &portName);
+    void probeForwardingState(const std::string &portName);
 
     /**
     *@method setMuxLinkmgrState
@@ -380,7 +380,7 @@ private:
     *
     *@return none
     */
-    void handleSetPeerMuxState(const std::string portName, mux_state::MuxState::Label label);
+    virtual void handleSetPeerMuxState(const std::string portName, mux_state::MuxState::Label label);
 
     /**
     *@method handleProbeMuxState
@@ -402,7 +402,7 @@ private:
      * 
      * @return none
      */
-    void handleProbeForwardingState(const std::string portName);
+    virtual void handleProbeForwardingState(const std::string portName);
 
     /**
     *@method handleSetMuxLinkmgrState

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -112,7 +112,7 @@ public:
     *
     *@return none
     */
-    inline void setMuxState(mux_state::MuxState::Label label) {mDbInterfacePtr->setMuxState(mMuxPortConfig.getPortName(), label);};
+    virtual inline void setMuxState(mux_state::MuxState::Label label) {mDbInterfacePtr->setMuxState(mMuxPortConfig.getPortName(), label);};
 
     /**
     *@method setPeerMuxState
@@ -170,7 +170,7 @@ public:
     *
     *@return none
     */
-    inline void postMetricsEvent(
+    virtual inline void postMetricsEvent(
         link_manager::ActiveStandbyStateMachine::Metrics metrics,
         mux_state::MuxState::Label label
     ) {

--- a/test/FakeDbInterface.cpp
+++ b/test/FakeDbInterface.cpp
@@ -46,7 +46,7 @@ void FakeDbInterface::handleSetMuxState(const std::string portName, mux_state::M
     mDbInterfaceRaceConditionCheckFailure = false;
 }
 
-void FakeDbInterface::setPeerMuxState(const std::string &portName, mux_state::MuxState::Label label)
+void FakeDbInterface::handleSetPeerMuxState(const std::string portName, mux_state::MuxState::Label label)
 {
     mLastSetPeerMuxState = label;
     mSetPeerMuxStateInvokeCount++;
@@ -62,7 +62,7 @@ void FakeDbInterface::probeMuxState(const std::string &portName)
     mProbeMuxStateInvokeCount++;
 }
 
-void FakeDbInterface::probeForwardingState(const std::string &portName)
+void FakeDbInterface::handleProbeForwardingState(const std::string portName)
 {
     mProbeForwardingStateInvokeCount++;
 }

--- a/test/FakeDbInterface.cpp
+++ b/test/FakeDbInterface.cpp
@@ -38,10 +38,12 @@ FakeDbInterface::FakeDbInterface(mux::MuxManager *muxManager, boost::asio::io_se
 {
 }
 
-void FakeDbInterface::setMuxState(const std::string &portName, mux_state::MuxState::Label label)
+void FakeDbInterface::handleSetMuxState(const std::string portName, mux_state::MuxState::Label label)
 {
     mLastSetMuxState = label;
     mSetMuxStateInvokeCount++;
+
+    mDbInterfaceRaceConditionCheckFailure = false;
 }
 
 void FakeDbInterface::setPeerMuxState(const std::string &portName, mux_state::MuxState::Label label)
@@ -70,13 +72,16 @@ void FakeDbInterface::setMuxLinkmgrState(const std::string &portName, link_manag
     mSetMuxLinkmgrStateInvokeCount++;
 }
 
-void FakeDbInterface::postMetricsEvent(
-    const std::string &portName,
-    link_manager::ActiveStandbyStateMachine::Metrics metrics,
-    mux_state::MuxState::Label label
+void FakeDbInterface::handlePostMuxMetrics(
+        const std::string portName,
+        link_manager::ActiveStandbyStateMachine::Metrics metrics,
+        mux_state::MuxState::Label label,
+        boost::posix_time::ptime time
 )
 {
     mPostMetricsInvokeCount++;
+
+    mDbInterfaceRaceConditionCheckFailure = true;
 }
 
 void FakeDbInterface::postLinkProberMetricsEvent(

--- a/test/FakeDbInterface.h
+++ b/test/FakeDbInterface.h
@@ -36,7 +36,7 @@ public:
     FakeDbInterface(mux::MuxManager *muxManager, boost::asio::io_service *ioService);
     virtual ~FakeDbInterface() = default;
 
-    virtual void setMuxState(const std::string &portName, mux_state::MuxState::Label label) override;
+    virtual void handleSetMuxState(const std::string portName, mux_state::MuxState::Label label) override;
     virtual void setPeerMuxState(const std::string &portName, mux_state::MuxState::Label label) override;
     virtual void getMuxState(const std::string &portName) override;
     virtual void probeMuxState(const std::string &portName) override;
@@ -45,10 +45,11 @@ public:
         const std::string &portName,
         link_manager::ActiveStandbyStateMachine::Label label
     ) override;
-    virtual void postMetricsEvent(
-        const std::string &portName,
+    virtual void handlePostMuxMetrics(
+        const std::string portName,
         link_manager::ActiveStandbyStateMachine::Metrics metrics,
-        mux_state::MuxState::Label label
+        mux_state::MuxState::Label label,
+        boost::posix_time::ptime time
     ) override;
     virtual void postLinkProberMetricsEvent(
         const std::string &portName, 
@@ -88,7 +89,10 @@ public:
     uint64_t mExpectedPacketCount = 0;
     uint32_t mSetMuxModeInvokeCount = 0;
     uint32_t mSetWarmStartStateReconciledInvokeCount = 0;
+    
     bool mWarmStartFlag = false;
+
+    bool mDbInterfaceRaceConditionCheckFailure = false;
 };
 
 } /* namespace test */

--- a/test/FakeDbInterface.h
+++ b/test/FakeDbInterface.h
@@ -37,10 +37,10 @@ public:
     virtual ~FakeDbInterface() = default;
 
     virtual void handleSetMuxState(const std::string portName, mux_state::MuxState::Label label) override;
-    virtual void setPeerMuxState(const std::string &portName, mux_state::MuxState::Label label) override;
+    virtual void handleSetPeerMuxState(const std::string portName, mux_state::MuxState::Label label) override;
     virtual void getMuxState(const std::string &portName) override;
     virtual void probeMuxState(const std::string &portName) override;
-    virtual void probeForwardingState(const std::string &portName) override;
+    virtual void handleProbeForwardingState(const std::string portName) override;
     virtual void setMuxLinkmgrState(
         const std::string &portName,
         link_manager::ActiveStandbyStateMachine::Label label

--- a/test/FakeMuxPort.h
+++ b/test/FakeMuxPort.h
@@ -47,6 +47,14 @@ public:
 
     void activateStateMachine();
 
+    virtual inline void postMetricsEvent(
+        link_manager::ActiveStandbyStateMachine::Metrics metrics,
+        mux_state::MuxState::Label label
+    ) {
+        mDbInterfacePtr->handlePostMuxMetrics(mMuxPortConfig.getPortName(), metrics, label, boost::posix_time::microsec_clock::universal_time());
+    };
+    virtual inline void setMuxState(mux_state::MuxState::Label label) {mDbInterfacePtr->handleSetMuxState(mMuxPortConfig.getPortName(), label);};
+
     std::shared_ptr<link_manager::ActiveActiveStateMachine> getActiveActiveStateMachinePtr() { return mActiveActiveStateMachinePtr; }
     std::shared_ptr<link_manager::ActiveStandbyStateMachine> getActiveStandbyStateMachinePtr() { return mActiveStandbyStateMachinePtr; }
     const link_manager::ActiveStandbyStateMachine::CompositeState& getCompositeState() { return getLinkManagerStateMachinePtr()->getCompositeState(); };

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -512,7 +512,7 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceMuxConfigA
     handleMuxState("unknown", 3);
     VALIDATE_STATE(Unknown, Unknown, Up);
 
-    handleMuxConfig("active", 1);
+    handleMuxConfig("active", 2);
     VALIDATE_STATE(Unknown, Active, Up);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
     EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
@@ -524,7 +524,7 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceMuxConfigA
     VALIDATE_STATE(Unknown, Unknown, Up);
 
     // xcvrd now answers the mux probe
-    handleProbeMuxState("active", 3);
+    handleProbeMuxState("active", 4);
     VALIDATE_STATE(Unknown, Active, Up);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
     EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
@@ -549,7 +549,7 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceMuxConfigA
     handleMuxState("unknown", 3);
     VALIDATE_STATE(Unknown, Unknown, Up);
 
-    handleMuxConfig("active", 1);
+    handleMuxConfig("active", 2);
     VALIDATE_STATE(Unknown, Active, Up);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
     EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
@@ -557,11 +557,11 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceMuxConfigA
     handleMuxState("unknown", 5);
     VALIDATE_STATE(Unknown, Unknown, Up);
 
-    handleProbeMuxState("unknown", 3);
+    handleProbeMuxState("unknown", 4);
     VALIDATE_STATE(Unknown, Unknown, Up);
 
     // xcvrd now answers the mux probe
-    handleProbeMuxState("standby", 3);
+    handleProbeMuxState("standby", 4);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
     EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
     handleMuxState("active", 3);

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -1004,16 +1004,18 @@ TEST_F(MuxManagerTest, DbInterfaceRaceConditionCheck)
 
     createPort("Ethernet0");
 
-    uint32_t TOGGLE_COUNT = 2000;
+    uint32_t TOGGLE_COUNT = 1000;
 
-    for (int i=0; i<TOGGLE_COUNT; i++) {
+    for (uint32_t i=0; i<TOGGLE_COUNT; i++) {
         postMetricsEvent("Ethernet0", mux_state::MuxState::Label::Active);
         setMuxState("Ethernet0", mux_state::MuxState::Label::Active);
-
+        
+        // wait for handler to be completed 
+        usleep(1000);
         EXPECT_FALSE(mDbInterfacePtr->mDbInterfaceRaceConditionCheckFailure);
+        EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, i+1);
+        EXPECT_EQ(mDbInterfacePtr->mPostMetricsInvokeCount, i+1);
     }
-    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, TOGGLE_COUNT);
-    EXPECT_EQ(mDbInterfacePtr->mPostMetricsInvokeCount, TOGGLE_COUNT);
 
     terminate();
 }

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -91,6 +91,8 @@ public:
     void resetUpdateEthernetFrameFn(const std::string &portName);
     void postMetricsEvent(const std::string &portName, mux_state::MuxState::Label label);
     void setMuxState(const std::string &portName, mux_state::MuxState::Label label);
+    void initializeThread();
+    void terminate();
 
 public:
     static const std::string PortName;

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -89,6 +89,8 @@ public:
     void updatePortReconciliationCount(int increment);
     void startWarmRestartReconciliationTimer(uint32_t timeout);
     void resetUpdateEthernetFrameFn(const std::string &portName);
+    void postMetricsEvent(const std::string &portName, mux_state::MuxState::Label label);
+    void setMuxState(const std::string &portName, mux_state::MuxState::Label label);
 
 public:
     static const std::string PortName;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to fix race condition introduced by `wrap` method of `boost::asio::io_service::strand`: 

> In the following case:
> 
> async_op_1(..., s.wrap(a));
> async_op_2(..., s.wrap(b));
>
> the completion of the first async operation will perform s.dispatch(a), and the second will perform s.dispatch(b), but the order in which those are performed is unspecified. That is, you cannot state whether one happens-before the other. Therefore, none of the above conditions are met and no ordering guarantee is made. 

sign-off: Jing Zhang zhangjing@microsoft.com 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To fix the bug that linkgmrd cleans mux metrics table __after__ setting mux state to orchagent. 

#### How did you do it?
1. Use ` boost::asio::post()` to replace `wrap`.
2. Add unit tests to cover this race condition scenario:
   * Remove override of `setMuxState`, `postMetricsEvent` in FakeDbinterface so the real implementation can be executed. 
   * Override  `setMuxState`, `postMetricsEvent` in FakeMuxPort as LinkManagerStateMachine tests use fake mux ports, so existing tests won't be broken. 
   * Initiate thread pool in MuxManager test to better mimic, and run 1000 times `setMuxState` & `postMetricsEvent` to reproduce.

#### How did you verify/test it?
Unit tests. Verified:
1. With `wrap`, issue was reproduced 14/1000 times. 
```
[  FAILED  ] 1 test, listed below:
[  FAILED  ] MuxManagerTest.DbInterfaceRaceConditionCheck
test/MuxManagerTest.cpp:1014: Failure
Value of: mDbInterfacePtr->mDbInterfaceRaceConditionCheckFailure
  Actual: true
Expected: false
...
```
2. With `boost::asio::post()`, issue was not reproducible. 


#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->