### PR TITLE
Backoff mux probing for server down scenario

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -792,6 +792,8 @@ void ActiveStandbyStateMachine::handleSuspendTimerExpiry()
         CompositeState currState = mCompositeState;
         enterMuxWaitState(mCompositeState);
         LOGINFO_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), currState, mCompositeState);
+    } else {
+        mUnknownActiveUpBackoffFactor = 1;
     }
 }
 
@@ -1057,7 +1059,9 @@ void ActiveStandbyStateMachine::LinkProberUnknownMuxActiveLinkUpTransitionFuncti
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
     // Suspend TX probes to help peer ToR takes over in case active link is bad
-    mSuspendTxFnPtr(mMuxPortConfig.getLinkWaitTimeout_msec());
+    mSuspendTxFnPtr(mMuxPortConfig.getLinkWaitTimeout_msec()*mUnknownActiveUpBackoffFactor);
+    mUnknownActiveUpBackoffFactor <<= 1;
+    mUnknownActiveUpBackoffFactor = mUnknownActiveUpBackoffFactor > MAX_BACKOFF_FACTOR ? MAX_BACKOFF_FACTOR : mUnknownActiveUpBackoffFactor;
     mWaitActiveUpCount = 0;
 }
 
@@ -1194,7 +1198,7 @@ void ActiveStandbyStateMachine::LinkProberWaitMuxActiveLinkUpTransitionFunction(
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
 
-    startMuxProbeTimer();
+    startMuxProbeTimer(mWaitActiveUpCount > 7? MAX_BACKOFF_FACTOR : (1<<mWaitActiveUpCount));
 
     if (mWaitActiveUpCount++ & 0x1) {
         mSuspendTxFnPtr(mMuxPortConfig.getLinkWaitTimeout_msec());

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -944,6 +944,12 @@ void ActiveStandbyStateMachine::handleMuxProbeTimeout(boost::system::error_code 
 {
     MUXLOGDEBUG(mMuxPortConfig.getPortName());
 
+    if (!(ps(mCompositeState) == link_prober::LinkProberState::Label::Wait &&
+         ms(mCompositeState) == mux_state::MuxState::Label::Standby &&
+         ls(mCompositeState) == link_state::LinkState::Label::Up)) {
+             mWaitStandbyUpBackoffFactor = 1;
+    }
+
     if (errorCode == boost::system::errc::success &&
         (ps(mCompositeState) == link_prober::LinkProberState::Label::Wait ||
          ms(mCompositeState) == mux_state::MuxState::Label::Unknown ||
@@ -1214,7 +1220,9 @@ void ActiveStandbyStateMachine::LinkProberWaitMuxStandbyLinkUpTransitionFunction
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
 
-    startMuxProbeTimer();
+    startMuxProbeTimer(mWaitStandbyUpBackoffFactor);
+    mWaitStandbyUpBackoffFactor <<= 1;
+    mWaitStandbyUpBackoffFactor = mWaitStandbyUpBackoffFactor > MAX_BACKOFF_FACTOR ? MAX_BACKOFF_FACTOR : mWaitStandbyUpBackoffFactor;
 }
 
 //

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -847,6 +847,7 @@ private:
 
     uint32_t mWaitActiveUpCount = 0;
     uint32_t mMuxUnknownBackoffFactor = 1;
+    uint32_t mWaitStandbyUpBackoffFactor = 1;
     uint32_t mUnknownActiveUpBackoffFactor = 1;
 
     bool mPendingMuxModeChange = false;

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -847,6 +847,7 @@ private:
 
     uint32_t mWaitActiveUpCount = 0;
     uint32_t mMuxUnknownBackoffFactor = 1;
+    uint32_t mUnknownActiveUpBackoffFactor = 1;
 
     bool mPendingMuxModeChange = false;
     common::MuxPortConfig::Mode mTargetMuxMode = common::MuxPortConfig::Mode::Auto;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to backoff mux probing when both sides are unable to receive ICMP heartbeat. In this case, originally, state machine will do mux state probing each 300ms. It will be too much when more than one interface is having the same issue, and it will cause delay in switchovers. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Improve switchover performance, reduce packet loss. 

#### How did you do it?
* Increment backoff factor every time state machine enters 
`LinkProber: Wait/Unknown, MuxState: Active, LinkState: Up`
`LinkProber: Wait, MuxState: Standby, LinkState: Up` 
* Set mux probe timer based on the backoff factor. 
* Reset factor when exiting the state. 

#### How did you verify/test it?
Tested with 1000 switchovers. The performance improvement is comparable to fully disabling mux probing. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->