### PR TITLE
Use `table` to toggle peer forwarding state

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -259,7 +259,7 @@ void DbInterface::initialize()
         mAppDbMuxTablePtr = std::make_shared<swss::ProducerStateTable> (
             mAppDbPtr.get(), APP_MUX_CABLE_TABLE_NAME
         );
-        mAppDbPeerMuxTablePtr = std::make_shared<swss::ProducerStateTable> (
+        mAppDbPeerMuxTablePtr = std::make_shared<swss::Table> (
             mAppDbPtr.get(), APP_PEER_HW_FORWARDING_STATE_TABLE_NAME
         );
         mAppDbMuxCommandTablePtr = std::make_shared<swss::Table> (
@@ -360,10 +360,7 @@ void DbInterface::handleSetPeerMuxState(const std::string portName, mux_state::M
     MUXLOGDEBUG(boost::format("%s: setting peer mux state to %s") % portName % mMuxState[label]);
 
     if (label <= mux_state::MuxState::Label::Unknown) {
-        std::vector<swss::FieldValueTuple> values = {
-            {"state", mMuxState[label]},
-        };
-        mAppDbPeerMuxTablePtr->set(portName, values);
+        mAppDbPeerMuxTablePtr->hset(portName, "state", mMuxState[label]);
     }
 }
 

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -841,7 +841,7 @@ private:
     // for communicating with orchagent
     std::shared_ptr<swss::ProducerStateTable> mAppDbMuxTablePtr;
     // for communication with driver (setting peer's forwarding state)
-    std::shared_ptr<swss::ProducerStateTable> mAppDbPeerMuxTablePtr;
+    std::shared_ptr<swss::Table> mAppDbPeerMuxTablePtr;
     // for communicating with the driver (probing the mux)
     std::shared_ptr<swss::Table> mAppDbMuxCommandTablePtr;
     // for communication with the driver (probing forwarding state)


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Fix peer toggle for `active-active` ports.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Use `table` to writes updates instead of `ProducerStateTable`.
For the peer toggle, `linkmgrd` directly talks to `ycabled` instead of `muxorch`, and `ProducerStateTable` is primarily used for interaction with `orchagent`.
Use `table` to write state updates is sufficient in this scenario.

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->