### PR TITLE
Adjust `DbInterfaceRaceConditionCheck` to Wait Longer for Handlers to be executed 

### DIFF
--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -1010,8 +1010,8 @@ TEST_F(MuxManagerTest, DbInterfaceRaceConditionCheck)
         postMetricsEvent("Ethernet0", mux_state::MuxState::Label::Active);
         setMuxState("Ethernet0", mux_state::MuxState::Label::Active);
         
-        // wait for handler to be completed 
-        usleep(1000);
+        // wait 10ms for handler to be completed 
+        usleep(10000);
         EXPECT_FALSE(mDbInterfacePtr->mDbInterfaceRaceConditionCheckFailure);
         EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, i+1);
         EXPECT_EQ(mDbInterfacePtr->mPostMetricsInvokeCount, i+1);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

The logic of `DbInterfaceRaceConditionCheck` test is loop 1000 times for the action below: 
1. post two jobs 
2. wait for 1 ms
3. assert if both jobs are completed
4. assert the execution order of two jobs

It seems like 1ms is not enough, jobs would be piled up. Even though it might eventually catch up, any of the 1000 assertion fails will lead to build failure. 

Hence incrementing time to 10ms now. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Make unit test more stable. 

#### How did you do it?
Increment waiting time for handlers to be executed. 

#### How did you verify/test it?
Build locally. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->