### PR TITLE
Fix flaky tests `DbInterfaceRaceConditionCheck`

### DIFF
--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -999,22 +999,22 @@ TEST_F(MuxManagerTest, TsaEnable)
 
 TEST_F(MuxManagerTest, DbInterfaceRaceConditionCheck)
 {
+    createPort("Ethernet0");
+
     // create thread pool
     initializeThread();
-
-    createPort("Ethernet0");
 
     uint32_t TOGGLE_COUNT = 1000;
 
     for (uint32_t i=0; i<TOGGLE_COUNT; i++) {
         postMetricsEvent("Ethernet0", mux_state::MuxState::Label::Active);
         setMuxState("Ethernet0", mux_state::MuxState::Label::Active);
-        
-        // wait 10ms for handler to be completed 
-        usleep(10000);
+
+        // wait for handlers to be completed 
+        while(mDbInterfacePtr->mSetMuxStateInvokeCount != i+1 || mDbInterfacePtr->mPostMetricsInvokeCount != i+1) {
+            usleep(10000);
+        }
         EXPECT_FALSE(mDbInterfacePtr->mDbInterfaceRaceConditionCheckFailure);
-        EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, i+1);
-        EXPECT_EQ(mDbInterfacePtr->mPostMetricsInvokeCount, i+1);
     }
 
     terminate();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to fix flaky test `DbInterfaceRaceConditionCheck`, Even #111 extended the wait time for handlers to complete, it's still not a guarantee, this test can still be unstable. Making an enhancement now to do a busy waiting on the hander invoke counts. 

Also 202012 branch's `createPort` function uses `boost::io_service::run_one` while master uses `poll_one`. `run_one` might block the calling thread until one event is ready to process. To avoid endless handing, adjust the order of initializing thread pool & creating port object. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [x] Unit test

### Approach
#### What is the motivation for this PR?
Make unit test stable in image building. 

#### How did you do it?
1. Busy wait on invoke count before checking. 
2. create port object before initialization of thread pools to avoid hanging. 
#### How did you verify/test it?
Build passes locally. 
#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->