### PR TITLE
Update linkmgr health after getting default route update

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -1070,6 +1070,7 @@ void ActiveActiveStateMachine::handleDefaultRouteStateNotification(const Default
 
     mDefaultRouteState = routeState;
     shutdownOrRestartLinkProberOnDefaultRoute();
+    updateMuxLinkmgrState();
 }
 
 //

--- a/test/FakeDbInterface.cpp
+++ b/test/FakeDbInterface.cpp
@@ -67,8 +67,9 @@ void FakeDbInterface::handleProbeForwardingState(const std::string portName)
     mProbeForwardingStateInvokeCount++;
 }
 
-void FakeDbInterface::setMuxLinkmgrState(const std::string &portName, link_manager::ActiveStandbyStateMachine::Label label)
+void FakeDbInterface::setMuxLinkmgrState(const std::string &portName, link_manager::LinkManagerStateMachineBase::Label label)
 {
+    mLastSetMuxLinkmgrState = label;
     mSetMuxLinkmgrStateInvokeCount++;
 }
 

--- a/test/FakeDbInterface.h
+++ b/test/FakeDbInterface.h
@@ -43,7 +43,7 @@ public:
     virtual void handleProbeForwardingState(const std::string portName) override;
     virtual void setMuxLinkmgrState(
         const std::string &portName,
-        link_manager::ActiveStandbyStateMachine::Label label
+        link_manager::LinkManagerStateMachineBase::Label label
     ) override;
     virtual void handlePostMuxMetrics(
         const std::string portName,
@@ -76,6 +76,7 @@ public:
 
     mux_state::MuxState::Label mLastSetMuxState;
     mux_state::MuxState::Label mLastSetPeerMuxState;
+    link_manager::LinkManagerStateMachineBase::Label mLastSetMuxLinkmgrState;
 
     uint32_t mSetMuxStateInvokeCount = 0;
     uint32_t mSetPeerMuxStateInvokeCount = 0;

--- a/test/FakeMuxPort.h
+++ b/test/FakeMuxPort.h
@@ -57,7 +57,7 @@ public:
 
     std::shared_ptr<link_manager::ActiveActiveStateMachine> getActiveActiveStateMachinePtr() { return mActiveActiveStateMachinePtr; }
     std::shared_ptr<link_manager::ActiveStandbyStateMachine> getActiveStandbyStateMachinePtr() { return mActiveStandbyStateMachinePtr; }
-    const link_manager::ActiveStandbyStateMachine::CompositeState& getCompositeState() { return getLinkManagerStateMachinePtr()->getCompositeState(); };
+    const link_manager::LinkManagerStateMachineBase::CompositeState& getCompositeState() { return getLinkManagerStateMachinePtr()->getCompositeState(); };
     link_prober::LinkProberStateMachineBase* getLinkProberStateMachinePtr() { return getLinkManagerStateMachinePtr()->getLinkProberStateMachinePtr().get(); };
     mux_state::MuxStateMachine& getMuxStateMachine() { return getLinkManagerStateMachinePtr()->getMuxStateMachine(); };
     link_state::LinkStateMachine& getLinkStateMachine() { return getLinkManagerStateMachinePtr()->getLinkStateMachine(); };

--- a/test/LinkManagerStateMachineActiveActiveTest.h
+++ b/test/LinkManagerStateMachineActiveActiveTest.h
@@ -43,7 +43,7 @@ public:
     void handleProbeMuxState(std::string, uint32_t count = 0);
     void handleLinkState(std::string linkState, uint32_t count = 0);
     void handleMuxConfig(std::string config, uint32_t count = 0);
-    void activateStateMachine();
+    void activateStateMachine(bool enable_feature_default_route=false);
     void setMuxActive();
     void setMuxStandby();
     void postDefaultRouteEvent(std::string routeState, uint32_t count = 0);


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #116 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Fix that `show mux status` shows `unhealthy` for `active-active` ports with heartbeats after `config load_minigraph`.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
After `linkmgrd` receives default route updates, let it update its health info.

#### How did you verify/test it?
Add unit-test.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->