### PR TITLE
[active-active] Remove unnecessary mux wait timeout logs

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -1012,11 +1012,6 @@ void ActiveActiveStateMachine::handleMuxWaitTimeout(boost::system::error_code er
         } else {
             MUXLOGTIMEOUT(mMuxPortConfig.getPortName(), "Unknown timeout reason!!!", mCompositeState);
         }
-        mMuxWaitBackoffFactor <<= 1;
-        mMuxWaitBackoffFactor = mMuxWaitBackoffFactor > MAX_BACKOFF_FACTOR ? MAX_BACKOFF_FACTOR : mMuxWaitBackoffFactor;
-        startMuxWaitTimer(mMuxWaitBackoffFactor);
-    } else {
-        mMuxWaitBackoffFactor = 1;
     }
 }
 
@@ -1051,11 +1046,6 @@ void ActiveActiveStateMachine::handlePeerMuxWaitTimeout(boost::system::error_cod
             "xcvrd timed out responding to linkmgrd peer mux state" %
             mMuxStateName[mPeerMuxState]
         );
-        mPeerMuxWaitBackoffFactor <<= 1;
-        mPeerMuxWaitBackoffFactor = mPeerMuxWaitBackoffFactor > MAX_BACKOFF_FACTOR ? MAX_BACKOFF_FACTOR : mPeerMuxWaitBackoffFactor;
-        startPeerMuxWaitTimer(mPeerMuxWaitBackoffFactor);
-    } else {
-        mPeerMuxWaitBackoffFactor = 1;
     }
 }
 

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -572,8 +572,6 @@ private: // peer link prober state and mux state
 
 private:
     uint32_t mMuxProbeBackoffFactor = 1;
-    uint32_t mMuxWaitBackoffFactor = 1;
-    uint32_t mPeerMuxWaitBackoffFactor = 1;
 
     boost::asio::deadline_timer mDeadlineTimer;
     boost::asio::deadline_timer mWaitTimer;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to remove repeating `handlePeerMuxWaitTimeout` and `handleMuxWaitTimeout` log message. 

When printing this log, linkmgrd doesn't do a retry or state change, so it's meaningless to repeat.  

When gRPC server is down, this message will become endless and cause unwanted syslog flood. 

sign-off: Jing Zhang zhangjing@microsoft.com


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Remove unnecessary chatty log message. 

#### How did you do it?
Stop starting mux wait timer again after first timeout. 

#### How did you verify/test it?
Existing Unit tests. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->