### PR TITLE
[active-active] post mux metrics events 

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -172,6 +172,7 @@ void ActiveActiveStateMachine::handleMuxStateNotification(mux_state::MuxState::L
         mProbePeerTorFnPtr();
         mResumeTxFnPtr();
         postMuxStateEvent(label);
+        mMuxPortPtr->postMetricsEvent(Metrics::SwitchingEnd, label);
     } else {
         if (label == mux_state::MuxState::Unknown) {
             // probe xcvrd to read the current mux state
@@ -829,6 +830,7 @@ void ActiveActiveStateMachine::switchMuxState(
         }
         enterMuxState(nextState, label);
         mMuxStateMachine.setWaitStateCause(mux_state::WaitState::WaitStateCause::SwssUpdate);
+        mMuxPortPtr->postMetricsEvent(Metrics::SwitchingStart, label);
         mMuxPortPtr->setMuxState(label);
         mDeadlineTimer.cancel();
         startMuxWaitTimer();

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -64,18 +64,6 @@ class ActiveStandbyStateMachine: public LinkManagerStateMachineBase,
                                public std::enable_shared_from_this<ActiveStandbyStateMachine>
 {
 public:
-    /**
-     *@enum Metrics
-     *
-     *@brief Metrics Data to be written to MUX_METRICS state db table
-     */
-    enum class Metrics {
-        SwitchingStart,
-        SwitchingEnd,
-
-        Count
-    };
-
     enum class LinkProberMetrics {
         LinkProberUnknownStart, 
         LinkProberUnknownEnd,

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -120,6 +120,18 @@ public:
 class LinkManagerStateMachineBase : public common::StateMachine {
 public:
     /**
+     *@enum Metrics
+     *
+     *@brief Metrics Data to be written to MUX_METRICS state db table
+     */
+    enum class Metrics {
+        SwitchingStart,
+        SwitchingEnd,
+
+        Count
+    };
+    
+    /**
      *@enum Label
      *
      *@brief Label corresponding to each LINKMGR Health State


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to fix missing mux metrics events for toggles of active-active ports. 

sign-off: Jing Zhang zhangjing@microsoft.com


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To store linkmgrd toggle start time and end time in state db.  

#### How did you do it?
* Post mux metrics `SwitchingStart` event in `switchMuxState` function. 
* Post mux metrics `SwitchingEnd` event when receive mux state notification after toggle. 

#### How did you verify/test it?
Tested on testbeds, was able to print mux metrics and `LAST_SWITCHOVER_TIME`: 

```
:~$ show mux metrics Ethernet12
PORT        EVENT                           TIME
----------  ------------------------------  ---------------------------
Ethernet12  linkmgrd_switch_active_start    2022-Aug-17 21:21:58.897637
Ethernet12  orch_switch_active_start        2022-Aug-17 21:21:58.907666
Ethernet12  orch_switch_active_end          2022-Aug-17 21:21:58.919903
Ethernet12  xcvrd_switch_self_active_start  2022-Aug-17 21:21:58.931162
Ethernet12  xcvrd_switch_self_active_end    2022-Aug-17 21:21:58.949198
Ethernet12  linkmgrd_switch_active_end      2022-Aug-17 21:21:58.966008

:~$ show mux status Ethernet12 
PORT        STATUS    SERVER_STATUS    HEALTH    HWSTATUS    LAST_SWITCHOVER_TIME
----------  --------  ---------------  --------  ----------  ---------------------------
Ethernet12  active    active           healthy   consistent  2022-Aug-17 21:21:58.966008
```
#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->