### PR TITLE
Update `handleMuxConfigNotification` logic

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -215,21 +215,19 @@ void ActiveActiveStateMachine::handleMuxConfigNotification(const common::MuxPort
 {
     if (mComponentInitState.all()) {
         CompositeState nextState = mCompositeState;
+        mMuxPortConfig.setMode(mode);
         if (mode == common::MuxPortConfig::Mode::Active && ms(mCompositeState) != mux_state::MuxState::Label::Active) {
-            switchMuxState(nextState, mux_state::MuxState::Label::Active);
+            switchMuxState(nextState, mux_state::MuxState::Label::Active, true);
         } else if (mode == common::MuxPortConfig::Mode::Standby && ms(mCompositeState) != mux_state::MuxState::Label::Standby) {
-            switchMuxState(nextState, mux_state::MuxState::Label::Standby);
+            switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
         } else {
-            // enforce link prober state to match mux state to trigger possible transitions
-            initLinkProberState(nextState);
-            probeMuxState();
+            // enforce a state transtion calculation based on current states
+            mStateTransitionHandler[ps(nextState)][ms(nextState)][ls(nextState)](nextState);
         }
         LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
         mCompositeState = nextState;
         updateMuxLinkmgrState();
     }
-
-    mMuxPortConfig.setMode(mode);
     shutdownOrRestartLinkProberOnDefaultRoute();
 }
 

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -324,15 +324,8 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveConfigStandby)
     VALIDATE_STATE(Active, Standby, Up);
 
     handleMuxConfig("auto", 1);
-    handleProbeMuxState("standby", 3);
-    VALIDATE_STATE(Unknown, Standby, Up);
-
-    postLinkProberEvent(link_prober::LinkProberState::Active, 3);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
     EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
-    VALIDATE_STATE(Active, Active, Up);
-
-    handleMuxState("active", 3);
     VALIDATE_STATE(Active, Active, Up);
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to handle https://github.com/sonic-net/sonic-linkmgrd/issues/119

Before, how linkmgrd handles `auto` configuration is: 
1. reset link prober state, trigger state change event
2. probe mux state. 

Issue here is, if gRPC state mismatching local state \&\& mux probe notification arrives before heartbeat events, local state can remain unchanged. Example is shown in https://github.com/sonic-net/sonic-linkmgrd/issues/119

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Handle toggle edge case. 

#### How did you do it?
Update handle mux config logics. 

#### How did you verify/test it?
Unit tests. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->