### PR TITLE
[linkmgrd] Replace memset function in link_prober

### DIFF
--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -21,6 +21,8 @@
  *      Author: tamer
  */
 
+#define __STDC_WANT_LIB_EXT1__ 1
+#include <string.h>
 #include <netpacket/packet.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
@@ -139,7 +141,11 @@ void LinkProber::initialize()
     }
 
     SockAddrLinkLayer addr;
+#ifdef __STDC_LIB_EXT1__
+    memset_s(&addr, sizeof(addr), 0, sizeof(addr));
+#else
     memset(&addr, 0, sizeof(addr));
+#endif
 
     addr.sll_ifindex = if_nametoindex(mMuxPortConfig.getPortName().c_str());
     addr.sll_family = AF_PACKET;
@@ -740,7 +746,11 @@ size_t LinkProber::appendTlvDummy(size_t paddingSize, int seqNo)
     Tlv *tlvPtr = reinterpret_cast<Tlv *> (mTxBuffer.data() + mTxPacketSize);
     tlvPtr->tlvhead.type = TlvType::TLV_DUMMY;
     tlvPtr->tlvhead.length = htons(paddingSize + sizeof(uint32_t));
+#ifdef __STDC_LIB_EXT1__
+    memset_s(tlvPtr->data, sizeof(tlvPtr->data), 0, paddingSize);
+#else
     memset(tlvPtr->data, 0, paddingSize);
+#endif
     *(reinterpret_cast<uint32_t *> (tlvPtr->data + paddingSize)) = htonl(seqNo);
     mTxPacketSize += tlvSize;
     return tlvSize;

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -130,6 +130,11 @@ LinkProber::LinkProber(
 //
 void LinkProber::initialize()
 {
+    SockAddrLinkLayer addr = {0};
+    addr.sll_ifindex = if_nametoindex(mMuxPortConfig.getPortName().c_str());
+    addr.sll_family = AF_PACKET;
+    addr.sll_protocol = htons(ETH_P_ALL);
+
     mSocket = socket(AF_PACKET, SOCK_RAW | SOCK_NONBLOCK, IPPROTO_ICMP);
     if (mSocket < 0) {
         std::ostringstream errMsg;
@@ -138,10 +143,6 @@ void LinkProber::initialize()
         throw MUX_ERROR(SocketError, errMsg.str());
     }
 
-    SockAddrLinkLayer addr = {0};
-    addr.sll_ifindex = if_nametoindex(mMuxPortConfig.getPortName().c_str());
-    addr.sll_family = AF_PACKET;
-    addr.sll_protocol = htons(ETH_P_ALL);
     if (bind(mSocket, (struct sockaddr *) &addr, sizeof(addr))) {
         std::ostringstream errMsg;
         errMsg << "Failed to bind to interface '" << mMuxPortConfig.getPortName() << "' with '"

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -21,8 +21,6 @@
  *      Author: tamer
  */
 
-#define __STDC_WANT_LIB_EXT1__ 1
-#include <string.h>
 #include <netpacket/packet.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
@@ -740,11 +738,7 @@ size_t LinkProber::appendTlvDummy(size_t paddingSize, int seqNo)
     Tlv *tlvPtr = reinterpret_cast<Tlv *> (mTxBuffer.data() + mTxPacketSize);
     tlvPtr->tlvhead.type = TlvType::TLV_DUMMY;
     tlvPtr->tlvhead.length = htons(paddingSize + sizeof(uint32_t));
-#ifdef __STDC_LIB_EXT1__
-    memset_s(tlvPtr->data, sizeof(tlvPtr->data), 0, paddingSize);
-#else
     memset(tlvPtr->data, 0, paddingSize);
-#endif
     *(reinterpret_cast<uint32_t *> (tlvPtr->data + paddingSize)) = htonl(seqNo);
     mTxPacketSize += tlvSize;
     return tlvSize;

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -140,13 +140,7 @@ void LinkProber::initialize()
         throw MUX_ERROR(SocketError, errMsg.str());
     }
 
-    SockAddrLinkLayer addr;
-#ifdef __STDC_LIB_EXT1__
-    memset_s(&addr, sizeof(addr), 0, sizeof(addr));
-#else
-    memset(&addr, 0, sizeof(addr));
-#endif
-
+    SockAddrLinkLayer addr = {0};
     addr.sll_ifindex = if_nametoindex(mMuxPortConfig.getPortName().c_str());
     addr.sll_family = AF_PACKET;
     addr.sll_protocol = htons(ETH_P_ALL);


### PR DESCRIPTION
Signed-off-by: maipbui <maibui@microsoft.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary: Replace insecure `memset` function in src/link_prober
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
`memset()` is an insecure function that can cause buffer overflow.
#### How did you do it?
Replace `memset()` by zero initialization
#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->