### PR TITLE
Fix mux config

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -213,9 +213,9 @@ void ActiveActiveStateMachine::handleSwssLinkStateNotification(const link_state:
 //
 void ActiveActiveStateMachine::handleMuxConfigNotification(const common::MuxPortConfig::Mode mode)
 {
+    mMuxPortConfig.setMode(mode);
     if (mComponentInitState.all()) {
         CompositeState nextState = mCompositeState;
-        mMuxPortConfig.setMode(mode);
         if (mode == common::MuxPortConfig::Mode::Active && ms(mCompositeState) != mux_state::MuxState::Label::Active) {
             switchMuxState(nextState, mux_state::MuxState::Label::Active, true);
         } else if (mode == common::MuxPortConfig::Mode::Standby && ms(mCompositeState) != mux_state::MuxState::Label::Standby) {

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -259,6 +259,11 @@ void LinkManagerStateMachineActiveActiveTest::postDefaultRouteEvent(std::string 
     runIoService(count);
 }
 
+const common::MuxPortConfig &LinkManagerStateMachineActiveActiveTest::getMuxPortConfig()
+{
+    return mFakeMuxPort.getMuxPortConfig();
+}
+
 TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActive)
 {
     setMuxActive();
@@ -579,6 +584,13 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceWriteActiv
 
     postDefaultRouteEvent("ok", 1);
     EXPECT_EQ(mDbInterfacePtr->mLastSetMuxLinkmgrState, link_manager::LinkManagerStateMachineBase::Label::Healthy);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, SetMuxConfigAutoBeforeInit)
+{
+    EXPECT_EQ(getMuxPortConfig().getMode(), common::MuxPortConfig::Mode::Auto);
+    handleMuxConfig("active", 1);
+    EXPECT_EQ(getMuxPortConfig().getMode(), common::MuxPortConfig::Mode::Active);
 }
 
 } /* namespace test */

--- a/test/LinkManagerStateMachineActiveActiveTest.h
+++ b/test/LinkManagerStateMachineActiveActiveTest.h
@@ -47,6 +47,7 @@ public:
     void setMuxActive();
     void setMuxStandby();
     void postDefaultRouteEvent(std::string routeState, uint32_t count = 0);
+    const common::MuxPortConfig &getMuxPortConfig();
 
 public:
     boost::asio::io_service mIoService;


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #127 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Fix the issue that `linkmgrd` fails to set mux config if mux config notification comes before all components are initialized.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?


#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->