### PR TITLE
[active-active] shutdown link prober when starting as isolated

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -85,6 +85,10 @@ void ActiveActiveStateMachine::activateStateMachine()
         LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
         mCompositeState = nextState;
 
+        if (mMuxPortConfig.ifEnableDefaultRouteFeature() == true)  {
+            shutdownOrRestartLinkProberOnDefaultRoute();
+        } 
+
         mInitializeProberFnPtr();
         mStartProbingFnPtr();
 
@@ -1074,7 +1078,7 @@ void ActiveActiveStateMachine::shutdownOrRestartLinkProberOnDefaultRoute()
     MUXLOGDEBUG(mMuxPortConfig.getPortName());
 
     if (mComponentInitState.all()) {
-        if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto && mDefaultRouteState == DefaultRoute::NA) {
+        if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto && mDefaultRouteState != DefaultRoute::OK) {
             mShutdownTxFnPtr();
         } else {
             // If mux mode is in manual/standby/active mode, we should restart link prober.

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -139,6 +139,10 @@ void FakeMuxPort::activateStateMachine()
     setComponentInitState(0);
     setComponentInitState(1);
     setComponentInitState(2);
+
+    if (mMuxPortConfig.ifEnableDefaultRouteFeature() == true){
+        mFakeLinkProber->shutdownTxProbes();
+    }
 }
 
 } /* namespace test */

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -215,8 +215,8 @@ void LinkManagerStateMachineActiveActiveTest::handleMuxConfig(std::string config
 
 void LinkManagerStateMachineActiveActiveTest::activateStateMachine(bool enable_feature_default_route)
 {
-    mFakeMuxPort.activateStateMachine();
     mMuxConfig.enableDefaultRouteFeature(enable_feature_default_route);
+    mFakeMuxPort.activateStateMachine();
 }
 
 void LinkManagerStateMachineActiveActiveTest::setMuxActive()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to shutdown link prober if default route entry is missing when `linkmgrd` starts. So the interface can be in `standby` if the device is isolated. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To keep isolated device in `standby`. 

#### How did you do it?
Shutdown link prober if default route is missing. 

#### How did you verify/test it?
Shutdown bgp, confirmed `ROUTE_TABLE` is removed. Then restart `linkmgrd` process, `active-active` interfaces are all `standby`. Did a tcpdump, no ICMP request was sent. 

Restart bgp, confirmed `ROUTE_TABLE` is added. `active-active` interfaces are back in `active`. Did a tcpdump, ICMP request showed up. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->