### PR TITLE
Post switchover reasons to STATE DB

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -205,7 +205,7 @@ void DbInterface::postSwitchCause(
         link_manager::ActiveStandbyStateMachine::SwitchCause cause
 )
 {
-    MUXLOGWARNING(boost::format("%s: post switch cause %s") %
+    MUXLOGDEBUG(boost::format("%s: post switch cause %s") %
         portName %
         mActiveStandbySwitchCause[static_cast<int>(cause)]
     );
@@ -234,7 +234,7 @@ void DbInterface::handlePostSwitchCause(
         boost::posix_time::ptime time
 )
 {
-    MUXLOGWARNING(boost::format("%s: post switch cause %s") %
+    MUXLOGDEBUG(boost::format("%s: post switch cause %s") %
         portName %
         mActiveStandbySwitchCause[static_cast<int>(cause)]
     );

--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -47,6 +47,7 @@ std::vector<std::string> DbInterface::mMuxState = {"active", "standby", "unknown
 std::vector<std::string> DbInterface::mMuxLinkmgrState = {"uninitialized", "unhealthy", "healthy"};
 std::vector<std::string> DbInterface::mMuxMetrics = {"start", "end"};
 std::vector<std::string> DbInterface::mLinkProbeMetrics = {"link_prober_unknown_start", "link_prober_unknown_end", "link_prober_wait_start", "link_prober_active_start", "link_prober_standby_start"};
+std::vector<std::string> DbInterface::mActiveStandbySwitchCause = {"Peer_Heartbeat_Missing" , "Peer_Link_Down" , "Tlv_Switch_Active_Command" , "Link_Down" , "Transceiver_Daemon_Timeout" , "Matching_Hardware_State" , "Config_Mux_Mode"};
 
 //
 // ---> DbInterface(mux::MuxManager *muxManager);
@@ -191,6 +192,58 @@ void DbInterface::postMetricsEvent(
     ));
 }
 
+//
+// ---> void postSwitchCause(
+//         const std::string &portName,
+//         link_manager::ActiveStandbyStateMachine::SwitchCause cause)
+//     );
+//
+// post switch cause
+//
+void DbInterface::postSwitchCause(
+        const std::string &portName,
+        link_manager::ActiveStandbyStateMachine::SwitchCause cause
+)
+{
+    MUXLOGWARNING(boost::format("%s: post switch cause %s") %
+        portName %
+        mActiveStandbySwitchCause[static_cast<int>(cause)]
+    );
+
+    boost::asio::post(mStrand, boost::bind(
+        &DbInterface::handlePostSwitchCause,
+        this,
+        portName,
+        cause,
+        boost::posix_time::microsec_clock::universal_time()
+    ));
+}
+
+//
+// ---> void handlePostSwitchCause(
+//          const std::string portName,
+//          link_manager::ActiveStandbyStateMachine::SwitchCause cause,
+//          boost::posix_time::ptime time
+//      );
+//
+// post switch cause to state db 
+//
+void DbInterface::handlePostSwitchCause(
+        const std::string &portName,
+        link_manager::ActiveStandbyStateMachine::SwitchCause cause,
+        boost::posix_time::ptime time
+)
+{
+    MUXLOGWARNING(boost::format("%s: post switch cause %s") %
+        portName %
+        mActiveStandbySwitchCause[static_cast<int>(cause)]
+    );
+
+    mStateDbSwitchCauseTablePtr->hset(portName, "cause", mActiveStandbySwitchCause[static_cast<int>(cause)]);
+    mStateDbSwitchCauseTablePtr->hset(portName, "time", boost::posix_time::to_simple_string(time));
+}
+
+
 // 
 // ---> postLinkProberMetricsEvent(
 //        const std::string &portName, 
@@ -276,6 +329,9 @@ void DbInterface::initialize()
         );
         mStateDbLinkProbeStatsTablePtr = std::make_shared<swss::Table> (
             mStateDbPtr.get(), LINK_PROBE_STATS_TABLE_NAME
+        );
+        mStateDbSwitchCauseTablePtr = std::make_shared<swss::Table> (
+            mStateDbPtr.get(),  STATE_MUX_SWITCH_CAUSE_TABLE_NAME
         );
         mMuxStateTablePtr = std::make_shared<swss::Table> (mStateDbPtr.get(), STATE_MUX_CABLE_TABLE_NAME);
 

--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -54,6 +54,8 @@ namespace mux
 #define APP_PEER_HW_FORWARDING_STATE_TABLE_NAME    "HW_FORWARDING_STATE_PEER"
 #define STATE_PEER_HW_FORWARDING_STATE_TABLE_NAME   "HW_MUX_CABLE_TABLE_PEER"
 
+#define STATE_MUX_SWITCH_CAUSE_TABLE_NAME "MUX_SWITCH_CAUSE"
+
 class MuxManager;
 using ServerIpPortMap = std::map<boost::asio::ip::address, std::string>;
 
@@ -231,6 +233,36 @@ public:
         const std::string portName,
         link_manager::ActiveStandbyStateMachine::Metrics metrics,
         mux_state::MuxState::Label label,
+        boost::posix_time::ptime time
+    );
+
+    /**
+     * @method postSwitchCause
+     * 
+     * @param portName (in) port name
+     * @param cause (in) switch cause 
+     * 
+     * @return none
+     */
+    virtual void postSwitchCause(
+        const std::string &portName,
+        link_manager::ActiveStandbyStateMachine::SwitchCause cause
+    );
+
+    /**
+     * @method handlePostSwitchCause
+     * 
+     * @brief post switch cause to state db 
+     * 
+     * @param portName (in) port Name
+     * @param cause (in) switch cause to post
+     * @param time (in) current time
+     * 
+     * @return none
+     */
+    void handlePostSwitchCause(
+        const std::string &portName,
+        link_manager::ActiveStandbyStateMachine::SwitchCause cause,
         boost::posix_time::ptime time
     );
 
@@ -829,6 +861,7 @@ private:
     static std::vector<std::string> mMuxLinkmgrState;
     static std::vector<std::string> mMuxMetrics;
     static std::vector<std::string> mLinkProbeMetrics;
+    static std::vector<std::string> mActiveStandbySwitchCause;
 
 private:
     mux::MuxManager *mMuxManagerPtr;
@@ -852,6 +885,8 @@ private:
     std::shared_ptr<swss::Table> mStateDbMuxMetricsTablePtr;
     // for writing link probe statistics data
     std::shared_ptr<swss::Table> mStateDbLinkProbeStatsTablePtr;
+    // for writing mux switch reason to state db 
+    std::shared_ptr<swss::Table> mStateDbSwitchCauseTablePtr;
 
     std::shared_ptr<boost::thread> mSwssThreadPtr;
 

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -178,6 +178,21 @@ public:
     };
 
     /**
+     * @method postSwitchCause
+     * 
+     * @brief post mux switch cause 
+     * 
+     * @param cause (in) switch cause to post 
+     * 
+     * @return none
+     */
+    virtual inline void postSwitchCause(
+        link_manager::ActiveStandbyStateMachine::SwitchCause cause
+    ) {
+        mDbInterfacePtr->postSwitchCause(mMuxPortConfig.getPortName(), cause);
+    };
+
+    /**
      * @method postLinkProberMetricsEvent
      * 
      * @brief post link prober pck loss event

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -33,7 +33,6 @@ namespace link_manager
 
 constexpr auto MAX_BACKOFF_FACTOR = 128;
 
-
 //
 // ---> ActiveStandbyStateMachine(
 //          mux::MuxPort *muxPortPtr,

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -74,6 +74,17 @@ public:
         Count
     };
 
+    enum class SwitchCause {
+        PeerHeartbeatMissing,
+        PeerLinkDown,
+        TlvSwitchActiveCommand,
+        LinkDown,
+        TransceiverDaemonTimeout,
+        MatchingHardwareState,
+        ConfigMuxMode,
+
+        Count
+    };
 public:
     /**
     *@method ActiveStandbyStateMachine
@@ -195,7 +206,7 @@ private:
     *
     *@return none
     */
-    inline void switchMuxState(CompositeState &nextState, mux_state::MuxState::Label label, bool forceSwitch = false);
+    inline void switchMuxState(link_manager::ActiveStandbyStateMachine::SwitchCause cause, CompositeState &nextState, mux_state::MuxState::Label label, bool forceSwitch = false);
 
     /**
      * @method shutdownOrRestartLinkProberOnDefaultRoute()
@@ -844,6 +855,8 @@ private:
     bool mContinuousLinkProberUnknownEvent = false; // When posting unknown_end event, we want to make sure the previous state is unknown.
 
     DefaultRoute mDefaultRouteState = DefaultRoute::Wait;
+
+    link_manager::ActiveStandbyStateMachine::SwitchCause mSendSwitchActiveCommandCause;
 };
 
 } /* namespace link_manager */

--- a/test/FakeDbInterface.cpp
+++ b/test/FakeDbInterface.cpp
@@ -123,4 +123,13 @@ void FakeDbInterface::setWarmStartStateReconciled()
     mSetWarmStartStateReconciledInvokeCount++;
 }
 
+void FakeDbInterface::postSwitchCause(
+    const std::string &portName,
+    link_manager::ActiveStandbyStateMachine::SwitchCause cause
+)
+{
+    mPostSwitchCauseInvokeCount++;
+    mLastPostedSwitchCause = cause;
+}
+
 } /* namespace test */

--- a/test/FakeDbInterface.h
+++ b/test/FakeDbInterface.h
@@ -63,6 +63,10 @@ public:
     virtual bool isWarmStart() override;
     virtual uint32_t getWarmStartTimer() override;
     virtual void setWarmStartStateReconciled() override; 
+    virtual void postSwitchCause(
+        const std::string &portName,
+        link_manager::ActiveStandbyStateMachine::SwitchCause cause
+    ) override;
 
     void setNextMuxState(mux_state::MuxState::Label label) {mNextMuxState = label;};
 
@@ -90,6 +94,9 @@ public:
     uint64_t mExpectedPacketCount = 0;
     uint32_t mSetMuxModeInvokeCount = 0;
     uint32_t mSetWarmStartStateReconciledInvokeCount = 0;
+    uint32_t mPostSwitchCauseInvokeCount = 0;
+
+    link_manager::ActiveStandbyStateMachine::SwitchCause mLastPostedSwitchCause;
     
     bool mWarmStartFlag = false;
 

--- a/test/FakeLinkProber.cpp
+++ b/test/FakeLinkProber.cpp
@@ -139,6 +139,18 @@ void FakeLinkProber::handleSendSwitchCommand()
     )));
 }
 
+void FakeLinkProber::handleSwitchCommandRecv()
+{
+    boost::asio::io_service::strand& strand = mLinkProberStateMachine->getStrand();
+    boost::asio::io_service &ioService = strand.context();
+    ioService.post(strand.wrap(boost::bind(
+        static_cast<void (link_prober::LinkProberStateMachineBase::*) (link_prober::SwitchActiveRequestEvent&)>
+            (&link_prober::LinkProberStateMachineBase::processEvent),
+        mLinkProberStateMachine,
+        link_prober::LinkProberStateMachineBase::getSwitchActiveRequestEvent()
+    )));
+}
+
 void FakeLinkProber::resetIcmpPacketCounts()
 {
     MUXLOGINFO("");

--- a/test/FakeLinkProber.h
+++ b/test/FakeLinkProber.h
@@ -52,6 +52,8 @@ public:
     void decreaseProbeIntervalAfterSwitch(uint32_t switchTime_msec);
     void revertProbeIntervalAfterSwitchComplete();
     void handleSendSwitchCommand();
+    void handleSwitchCommandRecv();
+
 
 
 public:

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -468,6 +468,29 @@ TEST_F(LinkManagerStateMachineTest, MuxActiveCliStandby)
     VALIDATE_STATE(Standby, Standby, Up);
 }
 
+TEST_F(LinkManagerStateMachineTest, MuxStandbyRecvSwitchActiveTlv)
+{
+    setMuxStandby();
+
+    mFakeMuxPort.mFakeLinkProber->handleSwitchCommandRecv();
+    runIoService(2);
+    VALIDATE_STATE(Wait, Wait, Up);
+    EXPECT_EQ(mDbInterfacePtr->mPostSwitchCauseInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastPostedSwitchCause, link_manager::ActiveStandbyStateMachine::SwitchCause::TlvSwitchActiveCommand);
+
+    // swss notification
+    handleMuxState("active", 3);
+    VALIDATE_STATE(Wait, Active, Up);
+
+    // change state to active
+    postLinkProberEvent(link_prober::LinkProberState::Active, 2);
+    VALIDATE_STATE(Active, Wait, Up);
+
+    // xcvrd notification
+    handleProbeMuxState("active", 4);
+    VALIDATE_STATE(Active, Active, Up);
+}
+
 TEST_F(LinkManagerStateMachineTest, MuxStandbyCliSwitchOverMuxFirst)
 {
     setMuxStandby();

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -452,6 +452,8 @@ TEST_F(LinkManagerStateMachineTest, MuxActiveCliStandby)
     mFakeMuxPort.mFakeLinkProber->handleSendSwitchCommand();
     runIoService(2);
     VALIDATE_STATE(Wait, Wait, Up);
+    EXPECT_EQ(mDbInterfacePtr->mPostSwitchCauseInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastPostedSwitchCause, link_manager::ActiveStandbyStateMachine::SwitchCause::ConfigMuxMode);
 
     // swss notification
     handleMuxState("standby", 3);
@@ -517,6 +519,8 @@ TEST_F(LinkManagerStateMachineTest, MuxActiveLinkDown)
 
     VALIDATE_STATE(Active, Wait, Down);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastPostedSwitchCause, link_manager::ActiveStandbyStateMachine::SwitchCause::LinkDown);
 
     // swss notification
     handleMuxState("standby", 4);
@@ -612,6 +616,8 @@ TEST_F(LinkManagerStateMachineTest, MuxStandbyLinkProberUnknown)
     postLinkProberEvent(link_prober::LinkProberState::Unknown, 2);
     VALIDATE_STATE(Wait, Wait, Up);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mPostSwitchCauseInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastPostedSwitchCause, link_manager::ActiveStandbyStateMachine::SwitchCause::PeerHeartbeatMissing);
 
     // swss notification
     handleMuxState("active", 3);
@@ -1112,6 +1118,8 @@ TEST_F(LinkManagerStateMachineTest, MuxStandbyPeerLinkStateDown)
 
     VALIDATE_STATE(Wait, Wait, Up);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mPostSwitchCauseInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastPostedSwitchCause, link_manager::ActiveStandbyStateMachine::SwitchCause::PeerLinkDown);
 
     postLinkProberEvent(link_prober::LinkProberState::Active, 3);
     VALIDATE_STATE(Active, Wait, Up);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
In production we saw unexpected switchover happen from time to time (switchovers that were not triggered by CLI or config change), we want to know what causes the switchover when troubleshooting.  Hence submitting this PR to post switchover cause to state DB. 


sign-off: Jing Zhang

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?  
To root cause unexpected switchovers quickly. 

#### How did you do it?
Introduced new table `MUX_SWITCH_CAUSE` to store switchover cause. 

#### How did you verify/test it?
* Unit tests
* Verified on DUT, causes were posted. 
```
admin@svcstr-7050-acs-1:~$ redis-cli -n 6 hgetall "MUX_SWITCH_CAUSE|Ethernet96"
1) "cause"
2) "Link_Down"
3) "time"
4) "2022-Sep-14 23:02:28.482322"
```

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->