### PR TITLE
[Active-Active] server side admin forwarding state sync up

### DIFF
--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -257,7 +257,7 @@ void MuxPort::handleProbeMuxState(const std::string &muxState)
     } else if (muxState == "failure" && mMuxPortConfig.getPortCableType() == common::MuxPortConfig::PortCableType::ActiveActive) {
         // gRPC connection failure for for active-active interfaces 
         boost::asio::post(mStrand, boost::bind(
-            &link_manager::LinkManagerStateMachineBase::handleControlPlaneConnectionFailure,
+            &link_manager::LinkManagerStateMachineBase::handleProbeMuxFailure,
             mLinkManagerStateMachinePtr.get()
         ));
 

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -254,14 +254,21 @@ void MuxPort::handleProbeMuxState(const std::string &muxState)
         label = mux_state::MuxState::Label::Active;
     } else if (muxState == "standby") {
         label = mux_state::MuxState::Label::Standby;
+    } else if (muxState == "failure" && mMuxPortConfig.getPortCableType() == common::MuxPortConfig::PortCableType::ActiveActive) {
+        // gRPC connection failure for for active-active interfaces 
+        boost::asio::post(mStrand, boost::bind(
+            &link_manager::LinkManagerStateMachineBase::handleControlPlaneConnectionFailure,
+            mLinkManagerStateMachinePtr.get()
+        ));
+
+        return;
     }
 
-    boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(
+    boost::asio::post(mStrand, boost::bind(
         &link_manager::LinkManagerStateMachineBase::handleProbeMuxStateNotification,
         mLinkManagerStateMachinePtr.get(),
         label
-    )));
+    ));
 }
 
 //

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -286,14 +286,15 @@ void ActiveActiveStateMachine::handleControlPlaneConnectionFailure()
     auto expiryTime = mWaitTimer.expires_at();
     auto now = boost::posix_time::microsec_clock::universal_time();
 
-    MUXLOGWARNING(boost::format("%s: lost gRPC connection, expiry time: %s, now: %s") 
+    MUXLOGINFO(boost::format("%s: lost gRPC connection, expiry time: %s, now: %s") 
         % mMuxPortConfig.getPortName() 
         % boost::posix_time::to_simple_string(expiryTime) 
         % boost::posix_time::to_simple_string(now)
     );
     
     if(expiryTime.is_not_a_date_time() || expiryTime < now) {
-        MUXLOGWARNING("");
+        MUXLOGDEBUG("");
+        
         probeMuxState();
     }
 }

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -276,11 +276,11 @@ void ActiveActiveStateMachine::handleProbeMuxStateNotification(mux_state::MuxSta
 }
 
 //
-// ---> handleControlPlaneConnectionFailure();
+// ---> handleProbeMuxFailure();
 //
 // handle gRPC connection failure 
 //
-void ActiveActiveStateMachine::handleControlPlaneConnectionFailure()
+void ActiveActiveStateMachine::handleProbeMuxFailure()
 {
     // If mWaitTimer is expired, no gRPC request in on-going, trigger a mux probe immediately. 
     auto expiryTime = mWaitTimer.expires_at();
@@ -293,8 +293,8 @@ void ActiveActiveStateMachine::handleControlPlaneConnectionFailure()
     );
     
     if(expiryTime.is_not_a_date_time() || expiryTime < now) {
-        MUXLOGDEBUG("");
-        
+        MUXLOGDEBUG(mMuxPortConfig.getPortName());
+
         probeMuxState();
     }
 }

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -276,6 +276,22 @@ void ActiveActiveStateMachine::handleProbeMuxStateNotification(mux_state::MuxSta
 }
 
 //
+// ---> handleControlPlaneConnectionFailure();
+//
+// handle gRPC connection failure 
+//
+void ActiveActiveStateMachine::handleControlPlaneConnectionFailure()
+{
+    // If mWaitTimer is expired, no gRPC request in on-going, trigger a mux probe immediately. 
+    uint32_t expiryTime = mWaitTimer.expires_from_now().total_milliseconds();
+
+    MUXLOGWARNING(boost::format("%s: lost gRPC connection, expiry time: %d.") % mMuxPortConfig.getPortName() % expiryTime);
+    if(expiryTime == 0) {
+        probeMuxState();
+    }
+}
+
+//
 // ---> handlePeerMuxStateNotification(mux_state::MuxState::Label label);
 //
 // handle peer MUX state notification

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -140,6 +140,15 @@ public: // db event handlers
     void handleProbeMuxStateNotification(mux_state::MuxState::Label label) override;
 
     /**
+     * @method handleControlPlaneConnectionFailure
+     * 
+     * @brief handle gRPC connection failure notification
+     * 
+     * @return none
+     */
+    void handleControlPlaneConnectionFailure() override;
+
+    /**
      * @method handlePeerMuxStateNotification
      *
      * @brief handle peer MUX state notification

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -140,13 +140,13 @@ public: // db event handlers
     void handleProbeMuxStateNotification(mux_state::MuxState::Label label) override;
 
     /**
-     * @method handleControlPlaneConnectionFailure
+     * @method handleProbeMuxFailure
      * 
      * @brief handle gRPC connection failure notification
      * 
      * @return none
      */
-    void handleControlPlaneConnectionFailure() override;
+    void handleProbeMuxFailure() override;
 
     /**
      * @method handlePeerMuxStateNotification

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -177,11 +177,11 @@ void LinkManagerStateMachineBase::handleUseWellKnownMacAddressNotification()
 }
 
 //
-// ---> handleControlPlaneConnectionFailure();
+// ---> handleProbeMuxFailure();
 //
 // handle control plane connection failure
 //
-void LinkManagerStateMachineBase::handleControlPlaneConnectionFailure()
+void LinkManagerStateMachineBase::handleProbeMuxFailure()
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
 

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -177,6 +177,17 @@ void LinkManagerStateMachineBase::handleUseWellKnownMacAddressNotification()
 }
 
 //
+// ---> handleControlPlaneConnectionFailure();
+//
+// handle control plane connection failure
+//
+void LinkManagerStateMachineBase::handleControlPlaneConnectionFailure()
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+
+}
+
+//
 // ---> handleGetMuxStateNotification(mux_state::MuxState::Label label);
 //
 // handle get MUX state notification

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -336,6 +336,15 @@ public:
     virtual void handleUseWellKnownMacAddressNotification();
 
     /**
+     * @method handleControlPlaneConnectionFailure
+     * 
+     * @brief handle control plane connection failure 
+     * 
+     * @return none
+     */
+    virtual void handleControlPlaneConnectionFailure();
+
+    /**
      *@method handleGetMuxStateNotification
      *
      *@brief handle get MUX state notification

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -336,13 +336,13 @@ public:
     virtual void handleUseWellKnownMacAddressNotification();
 
     /**
-     * @method handleControlPlaneConnectionFailure
+     * @method handleProbeMuxFailure
      * 
      * @brief handle control plane connection failure 
      * 
      * @return none
      */
-    virtual void handleControlPlaneConnectionFailure();
+    virtual void handleProbeMuxFailure();
 
     /**
      *@method handleGetMuxStateNotification

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -588,4 +588,19 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, SetMuxConfigAutoBeforeInit)
     EXPECT_EQ(getMuxPortConfig().getMode(), common::MuxPortConfig::Mode::Active);
 }
 
+TEST_F(LinkManagerStateMachineActiveActiveTest, GrpcTransientFailure)
+{
+    activateStateMachine();
+
+    postLinkEvent(link_state::LinkState::Up);
+    handleMuxState("active", 3);
+    postLinkProberEvent(link_prober::LinkProberState::Active, 4);
+    VALIDATE_STATE(Active, Active, Up);
+
+    mIoService.restart();
+    EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, 0);
+    handleProbeMuxState("failure", 2);
+    EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, 1);
+}
+
 } /* namespace test */


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to sync up server-side admin forwarding state in case it's out-of-date. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To make sure server-side admin forwarding state is up to date. 

#### How did you do it?
Every time ycabled gets a transient failure for gRPC connection, it writes to APP db. Make linkmgrd consume this notification: 
```
"FORWARDING_STATE_RESPONSE:PORTNAME": 
{
"response": "failure"
}
```
- If there is a gRPC request sent out earlier but not responded or timed out, do nothing. 
- It there isn't a gRPC request, do an immediate querying. 

#### How did you verify/test it?
Tested on DUT. 

When there is a gRPC request, `mWaitTimer` will is not expired, do nothing, wait for the mux state notification to trigger the action to avoid double backoff. 
```
Sep 19 20:40:45.218834 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:289 handleControlPlaneConnectionFailure: Ethernet4: lost gRPC connection, expiry time: 2022-Sep-19 20:40:47.875848, now: 2022-Sep-19 20:40:45.218398
```
When there isn't a gRPC request, trigger one query request: 
```
Sep 19 20:59:02.623277 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:289 handleControlPlaneConnectionFailure: Ethernet36: lost gRPC connection, expiry time: not-a-date-time, now: 2022-Sep-19 20:59:02.622752
Sep 19 20:59:02.623443 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:291 handleControlPlaneConnectionFailure: 


Sep 19 21:56:40.054142 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:289 handleControlPlaneConnectionFailure: Ethernet4: lost gRPC connection, expiry time: 2022-Sep-19 21:00:13.860333, now: 2022-Sep-19 21:56:40.053725
Sep 19 21:56:40.054142 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:291 handleControlPlaneConnectionFailure: 
```

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->