### PR TITLE
[Active-Active] flaky `LinkmgrdBootupSequence` unit tests

### DIFF
--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -452,13 +452,8 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceHeartBeatF
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
     EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
 
-    // now linkmgrd should be stuck in mux wait timeout
-
-    handleProbeMuxState("unknown", 3);
+    handleProbeMuxState("unknown", 4);
     VALIDATE_STATE(Active, Unknown, Up);
-
-    // now linkmgrd should be stuck in mux probe timeout
-    runIoService(4);
 
     // xcvrd now answers the mux probe
     handleProbeMuxState("active", 4);
@@ -519,7 +514,7 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceMuxConfigA
     handleMuxState("unknown", 5);
     VALIDATE_STATE(Unknown, Unknown, Up);
 
-    handleProbeMuxState("unknown", 3);
+    handleProbeMuxState("unknown", 4);
     VALIDATE_STATE(Unknown, Unknown, Up);
 
     // xcvrd now answers the mux probe


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to fix flaky unit tests. 

sign-off: Jing Zhang zhangjing@microsoft.com
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [x] Unit test

### Approach
#### What is the motivation for this PR?
Make tests more stable. 

#### How did you do it?
Add one more io_service run to `handleProbeMuxState('unknown') `.  If not, depending on the timing, sometimes it will have one more handler (`handleMuxWaitTimeout`) to execute and later switchover transactions can't be completed. 

#### How did you verify/test it?
Build linkmgrd. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->