### PR TITLE
[Active-Standby] fix syslog flood caused by `unkown -> standby` switchovers 

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -1147,7 +1147,13 @@ void ActiveStandbyStateMachine::LinkProberStandbyMuxUnknownLinkUpTransitionFunct
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
 
-    enterMuxWaitState(nextState);
+    if ((ps(mCompositeState) != ps(nextState)) &&
+        (ps(nextState) == link_prober::LinkProberState::Label::Active ||
+         ps(nextState) == link_prober::LinkProberState::Label::Standby)) {
+        enterMuxWaitState(nextState);
+    } else {
+        startMuxProbeTimer();
+    }
 }
 
 //

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -832,11 +832,11 @@ TEST_F(LinkManagerStateMachineTest, StandbyStateToProberUnknownMuxUnknownLinkUp)
 {
     setMuxStandby();
 
-    postMuxEvent(mux_state::MuxState::Unknown, 2);
+    postMuxEvent(mux_state::MuxState::Unknown, 3);
     VALIDATE_STATE(Standby, Wait, Up);
 
     // xcvrd notification
-    handleProbeMuxState("unknown", 3);
+    handleProbeMuxState("unknown", 4);
     VALIDATE_STATE(Standby, Wait, Up);
 
     postLinkProberEvent(link_prober::LinkProberState::Unknown, 2);
@@ -903,11 +903,11 @@ TEST_F(LinkManagerStateMachineTest, ProberWaitMuxUnknownLinkDown)
 {
     setMuxStandby();
 
-    postMuxEvent(mux_state::MuxState::Unknown, 2);
+    postMuxEvent(mux_state::MuxState::Unknown, 3);
     VALIDATE_STATE(Standby, Wait, Up);
 
     // xcvrd notification
-    handleProbeMuxState("unknown", 3);
+    handleProbeMuxState("unknown", 4);
     VALIDATE_STATE(Standby, Wait, Up);
 
     postLinkProberEvent(link_prober::LinkProberState::Unknown, 2);

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -948,7 +948,7 @@ TEST_F(LinkManagerStateMachineTest, ProberWaitMuxUnknownLinkDown)
 
 }
 
-TEST_F(LinkManagerStateMachineTest, MuxUnknownGetMuxStateActive)
+TEST_F(LinkManagerStateMachineTest, MuxUnknownGetMuxStateStandby)
 {
     setMuxActive();
 
@@ -956,9 +956,16 @@ TEST_F(LinkManagerStateMachineTest, MuxUnknownGetMuxStateActive)
     handleProbeMuxState("unknown", 3);
     VALIDATE_STATE(Unknown, Unknown, Up);
 
-    // even get mux state "active" in state db, which is mismatching from "unknown", LinkManager shouldn't switch to "unknown"
+    postLinkProberEvent(link_prober::LinkProberState::Standby, 3);
+    VALIDATE_STATE(Standby, Wait, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 2);
+    handleProbeMuxState("unknown", 3);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+
+    // even get mux state "standby" in state db, which is mismatching from "unknown", LinkManager shouldn't switch to "unknown"
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
-    handleGetMuxState("active", 2);
+    handleGetMuxState("standby", 2);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This is to fix the syslog flood issue caused by repeated switchovers from `unknown` to `standby`. The scenario trigged the issue was when xcvrd timed out toggles requests but was able to probe:
Linkmgrd toggles to `standby`
-> toggles fails, xcvrd writes `unknown`
-> linkmgrd probes mux state
-> xcvrd writes `standby`
-> linkmgrd toggles to `standby`  (previous mux state was `unknown`, switching to match)
-> toggles fails, xcvrd writes `unknown`
-> ... ...

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Avoid the syslog flood. 

#### How did you do it?
Avoid the immediate mux state probes if entering mux state `unknown`. Instead, start a mux probe timer of 300ms. 

#### How did you verify/test it?
Unit tests. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
Syslog of the issue: 
```
Jul 28 00:46:59.864911 XXXXXXXXXXXXXXXXXXXX NOTICE pmon#ycable[33]: Got a change event for toggle the mux-direction active side for port Ethernet16 state requested standby from old unknown to unknown Thread-3
Jul 28 00:46:59.865418 XXXXXXXXXXXXXXXXXXXX NOTICE swss#orchagent: :- addOperation: Mux setting State DB entry (hw state unknown, mux state unknown) for port Ethernet16
Jul 28 00:46:59.865892 XXXXXXXXXXXXXXXXXXXX WARNING mux#linkmgrd: MuxManager.cpp:211 addOrUpdateMuxPortMuxState: Ethernet16: state db mux state: unknown
Jul 28 00:46:59.866111 XXXXXXXXXXXXXXXXXXXX INFO caclmgrd[1217]: mux cable update : '('Ethernet16', 'SET', (('state', 'unknown'),))'
Jul 28 00:46:59.866101 XXXXXXXXXXXXXXXXXXXX WARNING mux#linkmgrd: link_manager/LinkManagerStateMachine.cpp:676 handleMuxStateNotification: Ethernet16: state db mux state: Unknown
Jul 28 00:46:59.868155 XXXXXXXXXXXXXXXXXXXX WARNING mux#linkmgrd: link_manager/LinkManagerStateMachine.cpp:291 setLabel: Ethernet16: Linkmgrd state is: Wait Unhealthy
Jul 28 00:46:59.877824 XXXXXXXXXXXXXXXXXXXX INFO caclmgrd[2084421]: iptables: Bad rule (does a matching rule exist in that chain?).
Jul 28 00:46:59.878609 XXXXXXXXXXXXXXXXXXXX WARNING mux#linkmgrd: link_manager/LinkManagerStateMachine.cpp:291 setLabel: Ethernet16: Linkmgrd state is: Standby Healthy
Jul 28 00:46:59.878852 XXXXXXXXXXXXXXXXXXXX WARNING mux#linkmgrd: link_manager/LinkManagerStateMachine.cpp:623 handleGetMuxStateNotification: Ethernet16: Switching MUX state from 'Unknown' to 'Standby' to match linkmgrd/xcvrd state
Jul 28 00:46:59.878852 XXXXXXXXXXXXXXXXXXXX WARNING mux#linkmgrd: link_manager/LinkManagerStateMachine.cpp:356 switchMuxState: Ethernet16: Switching MUX state to 'Standby'
Jul 28 00:46:59.879921 XXXXXXXXXXXXXXXXXXXX NOTICE swss#orchagent: :- setState: [Ethernet16] Set MUX state from standby to standby
Jul 28 00:46:59.880077 XXXXXXXXXXXXXXXXXXXX ERR swss#orchagent: :- setState: State transition from standby to standby is not-handled
Jul 28 00:46:59.880160 XXXXXXXXXXXXXXXXXXXX NOTICE swss#orchagent: :- addOperation: Mux State set to standby for port Ethernet16
Jul 28 00:46:59.884590 XXXXXXXXXXXXXXXXXXXX WARNING pmon#ycable[33]: ERR: Got a change event for toggle but could not toggle the mux-direction for port Ethernet16 state from unknown to standby, writing unknown
```