### PR TITLE
[Active-Active] Retry config mux mode standby

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -645,7 +645,9 @@ void ActiveActiveStateMachine::initializeTransitionFunctionTable()
 void ActiveActiveStateMachine::LinkProberActiveMuxActiveLinkUpTransitionFunction(CompositeState &nextState)
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
-    if (ms(mCompositeState) == mux_state::MuxState::Unknown) {
+    if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Standby) {
+        switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
+    } else if (ms(mCompositeState) != mux_state::MuxState::Active) {
         switchMuxState(nextState, mux_state::MuxState::Label::Active);
     }
 }

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -336,15 +336,20 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveConfigStandby)
     EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
     VALIDATE_STATE(Active, Standby, Up);
 
+    // if toggle fails
+    handleMuxState("active", 3);
+    VALIDATE_STATE(Active, Standby, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
+
     handleMuxState("standby", 3);
     VALIDATE_STATE(Active, Standby, Up);
 
     postLinkProberEvent(link_prober::LinkProberState::Active, 3);
-    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
     VALIDATE_STATE(Active, Standby, Up);
 
     handleMuxConfig("auto", 1);
-    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 4);
     EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
     VALIDATE_STATE(Active, Active, Up);
 }

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -336,7 +336,7 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveConfigStandby)
     EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
     VALIDATE_STATE(Active, Standby, Up);
 
-    // if toggle fails
+    // if toggle fails, will retry.
     handleMuxState("active", 3);
     VALIDATE_STATE(Active, Standby, Up);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to retry & keep the `standby` state after configuring mux mode. **It's NOT a fix for faiing to toggle standby, which we still need to investigate.**

The motivation is that, if toggle standby fails
-> later gRPC probe `active` 
-> state machine in `LinkProber==Active, Link==Up, Mux==Active`
-> consider it as a healthy state and no more action is triggered. 
But now, `show mux status` returns `standby` as linkmgrd last writes `standby`, tunnel route is added. And worst of all, we get stuck in this state unless we restart mux service, cause `config mux mode active` won't fix it as linkmgrd already consider itself in `active` and won't writes to app db to update. 

sign-off: Jing Zhang zhangjing@microsoft.com 


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Unit tests. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->