### PR TITLE
[Active-Active] Post link prober stats to state db 

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -437,7 +437,7 @@ void ActiveActiveStateMachine::handleStateChange(
         if (mContinuousLinkProberUnknownEvent == false && state == link_prober::LinkProberState::Label::Unknown) {
             mContinuousLinkProberUnknownEvent = true;
             mMuxPortPtr->postLinkProberMetricsEvent(link_manager::ActiveActiveStateMachine::LinkProberMetrics::LinkProberUnknownStart);
-        } }
+        } 
          
         CompositeState nextState = mCompositeState;
         ps(nextState) = state;

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -595,6 +595,17 @@ private: // testing only
      */
     void setRestartTxFnPtr(boost::function<void()> restartTxFnPtr) { mRestartTxFnPtr = restartTxFnPtr; }
 
+    /**
+     * @method setResetIcmpPacketCountsFnPtr
+     *
+     * @brief set ResetIcmpPacketCountsFnPtr. This method is used for testing
+     *
+     * @param resetIcmpPacketCountsFnPtr (in)           pointer to new restartTxFnPtr
+     *
+     * @return none
+     */
+    void setResetIcmpPacketCountsFnPtr(boost::function<void()> resetIcmpPacketCountsFnPtr) { mResetIcmpPacketCountsFnPtr = resetIcmpPacketCountsFnPtr; }
+
 private: // peer link prober state and mux state
     link_prober::LinkProberState::Label mPeerLinkProberState = link_prober::LinkProberState::Label::PeerWait;
     mux_state::MuxState::Label mPeerMuxState = mux_state::MuxState::Label::Wait;

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -188,6 +188,27 @@ public: // db event handlers
      */
     void handleUseWellKnownMacAddressNotification() override;
 
+    /**
+     * @method handlePostPckLossRatioNotification
+     * 
+     * @brief handle get post pck loss ratio 
+     * 
+     * @param unknownEventCount (in) count of missing icmp packets
+     * @param expectedPacketCount (in) count of expected icmp packets
+     * 
+     * @return none
+    */
+    void handlePostPckLossRatioNotification(const uint64_t unknownEventCount, const uint64_t expectedPacketCount) override;
+
+    /**
+     * @method handleResetLinkProberPckLossCount
+     * 
+     * @brief reset link prober heartbeat packet loss count 
+     * 
+     * @return none
+    */
+    void handleResetLinkProberPckLossCount() override;
+
 public: // link prober event handlers
     /**
      * @method handleSuspendTimerExpiry
@@ -593,8 +614,11 @@ private:
     boost::function<void()> mResumeTxFnPtr;
     boost::function<void()> mShutdownTxFnPtr;
     boost::function<void()> mRestartTxFnPtr;
+    boost::function<void ()> mResetIcmpPacketCountsFnPtr;
 
     DefaultRoute mDefaultRouteState = DefaultRoute::Wait;
+
+    bool mContinuousLinkProberUnknownEvent = false;
 };
 
 } /* namespace link_manager */

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -64,16 +64,6 @@ class ActiveStandbyStateMachine: public LinkManagerStateMachineBase,
                                public std::enable_shared_from_this<ActiveStandbyStateMachine>
 {
 public:
-    enum class LinkProberMetrics {
-        LinkProberUnknownStart, 
-        LinkProberUnknownEnd,
-        LinkProberWaitStart,
-        LinkProberActiveStart,
-        LinkProberStandbyStart,
-
-        Count
-    };
-
     enum class SwitchCause {
         PeerHeartbeatMissing,
         PeerLinkDown,

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -157,6 +157,22 @@ public:
         Count
     };
 
+    /**
+     * @enum LinkProberMetrics
+     * 
+     * @brief labels corresponding to each link prober event
+     */
+    enum class LinkProberMetrics {
+        LinkProberUnknownStart, 
+        LinkProberUnknownEnd,
+        LinkProberWaitStart,
+        LinkProberActiveStart,
+        LinkProberStandbyStart,
+
+        Count
+    };
+
+
     using CompositeState = std::tuple<link_prober::LinkProberState::Label,
                                       mux_state::MuxState::Label,
                                       link_state::LinkState::Label>;

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -930,7 +930,7 @@ void LinkProber::reportHeartbeatReplyNotReceivedActiveActive()
 {
     if (mTxSeqNo != mRxSelfSeqNo) {
         mLinkProberStateMachinePtr->postLinkProberStateEvent(LinkProberStateMachineBase::getIcmpUnknownEvent());
-        mIcmpUnknownEventCount;
+        mIcmpUnknownEventCount++;
     }
     if (mTxSeqNo != mRxPeerSeqNo) {
         mLinkProberStateMachinePtr->postLinkProberStateEvent(LinkProberStateMachineBase::getIcmpPeerUnknownEvent());

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -930,6 +930,7 @@ void LinkProber::reportHeartbeatReplyNotReceivedActiveActive()
 {
     if (mTxSeqNo != mRxSelfSeqNo) {
         mLinkProberStateMachinePtr->postLinkProberStateEvent(LinkProberStateMachineBase::getIcmpUnknownEvent());
+        mIcmpUnknownEventCount;
     }
     if (mTxSeqNo != mRxPeerSeqNo) {
         mLinkProberStateMachinePtr->postLinkProberStateEvent(LinkProberStateMachineBase::getIcmpPeerUnknownEvent());

--- a/src/link_prober/LinkProberStateMachineActiveActive.cpp
+++ b/src/link_prober/LinkProberStateMachineActiveActive.cpp
@@ -198,4 +198,20 @@ inline void LinkProberStateMachineActiveActive::postLinkManagerPeerEvent(LinkPro
     )));
 }
 
+// 
+// ---> handlePckLossRatioUpdate(const uint64_t unknownEventCount, const uint64_t expectedPacketCount);
+//
+// post pck loss ratio update to link manager
+//
+void LinkProberStateMachineActiveActive::handlePckLossRatioUpdate(const uint64_t unknownEventCount, const uint64_t expectedPacketCount) 
+{
+    boost::asio::io_service::strand &strand = mLinkManagerStateMachinePtr->getStrand();
+    boost::asio::post(strand, boost::bind(
+        &link_manager::LinkManagerStateMachineBase::handlePostPckLossRatioNotification,
+        mLinkManagerStateMachinePtr,
+        unknownEventCount,
+        expectedPacketCount
+    ));
+}
+
 } /* namespace link_prober */

--- a/src/link_prober/LinkProberStateMachineActiveActive.h
+++ b/src/link_prober/LinkProberStateMachineActiveActive.h
@@ -138,6 +138,18 @@ public:
      */
     void enterPeerState(LinkProberState::Label label) override;
 
+    /**
+     * @method handlePckLossRatioUpdate
+     * 
+     * @brief post pck loss ratio update to link manager
+     * 
+     * @param unknownEventCount (in) count of missing icmp packets
+     * @param expectedPacketCount (in) count of expected icmp packets
+     * 
+     * @return none
+    */
+    void handlePckLossRatioUpdate(const uint64_t unknownEventCount, const uint64_t expectedPacketCount) override;
+
 private:
     /**
      *@method setCurrentPeerState

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -95,6 +95,9 @@ inline void FakeMuxPort::initLinkProberActiveActive()
     getActiveActiveStateMachinePtr()->setRestartTxFnPtr(
         boost::bind(&FakeLinkProber::restartTxProbes, mFakeLinkProber.get())
     );
+    getActiveActiveStateMachinePtr()->setResetIcmpPacketCountsFnPtr(
+        boost::bind(&FakeLinkProber::resetIcmpPacketCounts, mFakeLinkProber.get())
+    );
 }
 
 inline void FakeMuxPort::initLinkProberActiveStandby()

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -641,7 +641,7 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, GrpcTransientFailure)
 
 TEST_F(LinkManagerStateMachineActiveActiveTest, PostPckLossMetricsEvent) 
 {
-    setMuxStandby();
+    setMuxActive();
 
     EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 0);
     postLinkProberEvent(link_prober::LinkProberState::Unknown, 3);

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -219,6 +219,22 @@ void LinkManagerStateMachineActiveActiveTest::activateStateMachine(bool enable_f
     mFakeMuxPort.activateStateMachine();
 }
 
+void LinkManagerStateMachineActiveActiveTest::postPckLossRatioUpdateEvent(uint64_t unknownCount, uint64_t totalCount)
+{
+    mFakeMuxPort.postPckLossRatio(unknownCount, totalCount);
+    mFakeMuxPort.mFakeLinkProber->mIcmpUnknownEventCount = unknownCount;
+    mFakeMuxPort.mFakeLinkProber->mIcmpPacketCount = totalCount;
+
+    runIoService();
+}
+
+void LinkManagerStateMachineActiveActiveTest::postPckLossCountsResetEvent()
+{
+    mFakeMuxPort.resetPckLossCount();
+
+    runIoService(4);
+}
+
 TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceRepeatedMuxUnkown)
 {
     // This unit test needs to run before any execution activatestateMachine();
@@ -623,4 +639,34 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, GrpcTransientFailure)
     EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, 1);
 }
 
+TEST_F(LinkManagerStateMachineActiveActiveTest, PostPckLossMetricsEvent) 
+{
+    setMuxStandby();
+
+    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 0);
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 3);
+
+    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 1);
+    postLinkProberEvent(link_prober::LinkProberState::Active, 3);
+
+    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 2);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, PostPckLossUpdateAndResetEvent)
+{
+    uint64_t unknownCount = 999;
+    uint64_t totalCount = 10000;
+
+    postPckLossRatioUpdateEvent(unknownCount,totalCount);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mIcmpUnknownEventCount, unknownCount);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mIcmpPacketCount, totalCount);
+    EXPECT_EQ(mDbInterfacePtr->mUnknownEventCount, unknownCount);
+    EXPECT_EQ(mDbInterfacePtr->mExpectedPacketCount, totalCount);
+
+    postPckLossCountsResetEvent();
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mIcmpUnknownEventCount, 0);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mIcmpPacketCount, 0);
+    EXPECT_EQ(mDbInterfacePtr->mUnknownEventCount, 0);
+    EXPECT_EQ(mDbInterfacePtr->mExpectedPacketCount, 0);    
+}
 } /* namespace test */

--- a/test/LinkManagerStateMachineActiveActiveTest.h
+++ b/test/LinkManagerStateMachineActiveActiveTest.h
@@ -48,6 +48,8 @@ public:
     void setMuxStandby();
     void postDefaultRouteEvent(std::string routeState, uint32_t count = 0);
     const common::MuxPortConfig &getMuxPortConfig();
+    void postPckLossRatioUpdateEvent(uint64_t unknownCount, uint64_t totalCount);
+    void postPckLossCountsResetEvent();
 
 public:
     boost::asio::io_service mIoService;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to post link prober stats to state db for active-active interfaces.

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested on DUT. 
* Init
```
admin@svcstr-7050-acs-1:~$ sudo show mux packetloss Ethernet24
PORT        COUNT                 VALUE
----------  ------------------  -------
Ethernet24  pck_loss_count            0
Ethernet24  pck_expected_count      177
PORT    EVENT    TIME
------  -------  ------
```
* Shutdown interface
```
admin@svcstr-7050-acs-1:~$ sudo config interface shutdown Ethernet24
admin@svcstr-7050-acs-1:~$ sudo show mux packetloss Ethernet24
PORT        COUNT                 VALUE
----------  ------------------  -------
Ethernet24  pck_loss_count            2
Ethernet24  pck_expected_count      207
PORT        EVENT                      TIME
----------  -------------------------  ---------------------------
Ethernet24  link_prober_unknown_start  2022-Oct-04 00:29:15.346297
```
* startup interface
```
admin@svcstr-7050-acs-1:~$ sudo config interface startup Ethernet24
admin@svcstr-7050-acs-1:~$ sudo show mux packetloss Ethernet24
PORT        COUNT                 VALUE
----------  ------------------  -------
Ethernet24  pck_expected_count      228
Ethernet24  pck_loss_count           23
PORT        EVENT                      TIME
----------  -------------------------  ---------------------------
Ethernet24  link_prober_unknown_start  2022-Oct-04 00:29:15.346297
Ethernet24  link_prober_unknown_end    2022-Oct-04 00:29:35.350380
```
* Reset count 
```
admin@svcstr-7050-acs-1:~$ sudo config mux packetloss reset Ethernet24
admin@svcstr-7050-acs-1:~$ sudo show mux packetloss Ethernet24
PORT        COUNT                 VALUE
----------  ------------------  -------
Ethernet24  pck_loss_count            0
Ethernet24  pck_expected_count        3
```




#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->