### PR TITLE
[Active-Active] Update default route shutdown heartbeat logic

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -1135,10 +1135,13 @@ void ActiveActiveStateMachine::shutdownOrRestartLinkProberOnDefaultRoute()
     MUXLOGDEBUG(mMuxPortConfig.getPortName());
 
     if (mComponentInitState.all()) {
-        if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto && mDefaultRouteState != DefaultRoute::OK) {
+        if ((mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto ||
+            mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Detached ||
+            mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Standby)
+            && mDefaultRouteState != DefaultRoute::OK) {
             mShutdownTxFnPtr();
         } else {
-            // If mux mode is in manual/standby/active mode, we should restart link prober.
+            // If mux mode is in manual/active mode, we should restart link prober.
             // If default route state is "ok", we should retart link prober.
             mRestartTxFnPtr();
         }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

I observed that in some cases shutting down bgp sessions didn't make active-active interfaces get into `standby` state. The issue was mux mode was not in `auto` mode. But actually, even in `standby` mode & `detach` mode we should still force it to toggle to `standby` (by shutting down icmp heartbeat.)

When mux mode in `standby`

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Tested different mux mode with bgp sessions on and off. Heartbeats were disabled and enabled as expected. 


#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->