### PR TITLE
[Active-Standby] avoid posting mux metrics event when receiving unsolicited mux state notification 

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -671,10 +671,13 @@ void ActiveStandbyStateMachine::handleMuxStateNotification(mux_state::MuxState::
             MUXLOGWARNING(boost::format("%s: Received unsolicited MUX state change notification!") %
                 mMuxPortConfig.getPortName()
             );
-        }
+        } 
         mProbePeerTorFnPtr();
         postMuxStateEvent(label);
-        mMuxPortPtr->postMetricsEvent(Metrics::SwitchingEnd, label);
+        if (mMuxStateMachine.testWaitStateCause(mux_state::WaitState::WaitStateCause::SwssUpdate)) {
+            mMuxPortPtr->postMetricsEvent(Metrics::SwitchingEnd, label);
+            mMuxStateMachine.resetWaitStateCause(mux_state::WaitState::WaitStateCause::SwssUpdate);
+        }
     } else if (label == mux_state::MuxState::Unknown) {
         // state db may not have been initialized with up-to-date mux state
         // probe xcvrd to read the current mux state

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -671,7 +671,7 @@ void ActiveStandbyStateMachine::handleMuxStateNotification(mux_state::MuxState::
             MUXLOGWARNING(boost::format("%s: Received unsolicited MUX state change notification!") %
                 mMuxPortConfig.getPortName()
             );
-        } 
+        }
         mProbePeerTorFnPtr();
         postMuxStateEvent(label);
         if (mMuxStateMachine.testWaitStateCause(mux_state::WaitState::WaitStateCause::SwssUpdate)) {

--- a/src/mux_state/MuxStateMachine.h
+++ b/src/mux_state/MuxStateMachine.h
@@ -257,6 +257,28 @@ public:
     void setWaitStateCause(WaitState::WaitStateCause waitStateCause) {mWaitState.setWaitStateCause(waitStateCause);};
 
     /**
+    *@method testWaitStateCause
+    *
+    *@brief testter Wait Cause
+    *
+    *@param waitStateCause (in)  cause for entering wait state
+    *
+    *@return bool
+    */
+    bool testWaitStateCause(WaitState::WaitStateCause waitStateCause) {return mWaitState.testWaitStateCause(waitStateCause);};
+
+    /**
+    *@method resetWaitStateCause
+    *
+    *@brief resetter Wait Cause
+    *
+    *@param waitStateCause (in)  cause for entering wait state
+    *
+    *@return none
+    */
+    void resetWaitStateCause(WaitState::WaitStateCause waitStateCause) {mWaitState.resetWaitStateCause(waitStateCause);};
+
+    /**
     *@method getWaitOnSwssNotification
     *
     *@brief getter Wait Cause

--- a/src/mux_state/WaitState.cpp
+++ b/src/mux_state/WaitState.cpp
@@ -163,4 +163,15 @@ void WaitState::resetState()
     mErrorEventCount = 0;
 }
 
+//
+// setWaitStateCause(WaitStateCause waitStateCause)
+//
+// setter Wait Cause
+//    
+void WaitState::setWaitStateCause(WaitStateCause waitStateCause) 
+{
+    mLastWaitStateCause = waitStateCause;
+    mWaitStateCause.set(waitStateCause);
+}
+
 } /* namespace mux_state */

--- a/src/mux_state/WaitState.h
+++ b/src/mux_state/WaitState.h
@@ -24,6 +24,8 @@
 #ifndef MUX_STATE_WAITSTATE_H_
 #define MUX_STATE_WAITSTATE_H_
 
+#include <bitset>
+
 #include <mux_state/MuxState.h>
 
 namespace mux_state
@@ -45,7 +47,9 @@ public:
     enum WaitStateCause {
         CauseUnknown,
         SwssUpdate,
-        DriverUpdate
+        DriverUpdate,
+
+        WaitStateCauseCount
     };
 
 public:
@@ -156,7 +160,29 @@ public:
     *
     *@return none
     */
-    void setWaitStateCause(WaitStateCause waitStateCause) {mWaitStateCause = waitStateCause;};
+    void setWaitStateCause(WaitStateCause waitStateCause);
+
+    /**
+     * @method testWaitStateCause
+     * 
+     * @brief testter wait cause
+     * 
+     * @param waitStateCause (in) casue for entering wait state
+     * 
+     * @return bool 
+     */
+    bool testWaitStateCause(WaitStateCause waitStateCause) {return mWaitStateCause.test(waitStateCause);};
+
+    /**
+     * @method resetWaitStateCause
+     * 
+     * @brief reset wait casue 
+     * 
+     * @param waitStateCause (in) cause for entering wait state
+     * 
+     * @return none
+     */
+    void resetWaitStateCause(WaitStateCause waitStateCause) {mWaitStateCause.reset(waitStateCause);};
 
     /**
     *@method getWaitOnSwssNotification
@@ -165,7 +191,7 @@ public:
     *
     *@return cause for entering wait state
     */
-    WaitStateCause getWaitStateCause() const {return mWaitStateCause;};
+    WaitStateCause getWaitStateCause() const {return mLastWaitStateCause;};
 
 private:
     uint8_t mActiveEventCount = 0;
@@ -173,7 +199,8 @@ private:
     uint8_t mUnknownEventCount = 0;
     uint8_t mErrorEventCount = 0;
 
-    WaitStateCause mWaitStateCause = CauseUnknown;
+    WaitStateCause mLastWaitStateCause = CauseUnknown;
+    std::bitset<WaitStateCauseCount> mWaitStateCause = {0};
 };
 
 } /* namespace mux_state */


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to fix incorrect mux metrics timestamps caused by unsolicited mux state notification. 

Sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To avoid inaccurate `linkmgrd_switch_standby_end` timestamp. 
```
zhangjing@SJC20-0101-0712-03LT0:~$ show mux metrics Ethernet16
PORT        EVENT                          TIME
----------  -----------------------------  ---------------------------
Ethernet16  linkmgrd_switch_standby_start  2022-Sep-17 22:15:37.045516
Ethernet16  orch_switch_standby_start      2022-Sep-17 22:15:37.047081
Ethernet16  orch_switch_standby_end        2022-Sep-17 22:15:37.096656
Ethernet16  xcvrd_switch_standby_start     2022-Sep-17 22:15:37.123937
Ethernet16  xcvrd_switch_standby_end       2022-Sep-17 22:15:37.129636
Ethernet16  linkmgrd_switch_standby_end    2022-Sep-18 10:29:55.900190
```

#### How did you do it?
Post mux metrics event only if there is on-going toggling. 

#### How did you verify/test it?
Issue was very reproducible before: 
```
admin@str2-7260cx3-acs-12:~$ show mux metrics Ethernet100 
PORT         EVENT                          TIME
-----------  -----------------------------  ---------------------------
Ethernet100  linkmgrd_switch_standby_start  2022-Oct-06 18:16:48.806438
Ethernet100  orch_switch_standby_start      2022-Oct-06 18:16:48.873197
Ethernet100  orch_switch_standby_end        2022-Oct-06 18:16:48.875612
Ethernet100  xcvrd_switch_standby_start     2022-Oct-06 18:16:48.884182
Ethernet100  xcvrd_switch_standby_end       2022-Oct-06 18:16:48.888821
Ethernet100  linkmgrd_switch_standby_end    2022-Oct-06 18:16:48.890460
admin@str2-7260cx3-acs-12:~$ redis-cli -n 6 hset "HW_MUX_CABLE_TABLE|Ethernet100" state standby
(integer) 0
admin@str2-7260cx3-acs-12:~$ show mux metrics Ethernet100 
PORT         EVENT                          TIME
-----------  -----------------------------  ---------------------------
Ethernet100  linkmgrd_switch_standby_start  2022-Oct-06 18:16:48.806438
Ethernet100  orch_switch_standby_start      2022-Oct-06 18:16:48.873197
Ethernet100  orch_switch_standby_end        2022-Oct-06 18:16:48.875612
Ethernet100  xcvrd_switch_standby_start     2022-Oct-06 18:16:48.884182
Ethernet100  xcvrd_switch_standby_end       2022-Oct-06 18:16:48.888821
Ethernet100  linkmgrd_switch_standby_end    2022-Oct-06 23:38:57.580651
```

With the change, issue is no longer reproducible:
```
dmin@str2-7260cx3-acs-12:~$ show mux metrics Ethernet100 
PORT         EVENT                          TIME
-----------  -----------------------------  ---------------------------
Ethernet100  linkmgrd_switch_standby_start  2022-Oct-06 23:41:20.023126
Ethernet100  orch_switch_standby_start      2022-Oct-06 23:41:20.024741
Ethernet100  orch_switch_standby_end        2022-Oct-06 23:41:20.027517
Ethernet100  xcvrd_switch_standby_start     2022-Oct-06 23:41:20.034635
Ethernet100  xcvrd_switch_standby_end       2022-Oct-06 23:41:20.090085
Ethernet100  linkmgrd_switch_standby_end    2022-Oct-06 23:41:20.091313
admin@str2-7260cx3-acs-12:~$ redis-cli -n 6 hset "HW_MUX_CABLE_TABLE|Ethernet100" state standby
(integer) 0
admin@str2-7260cx3-acs-12:~$ show mux metrics Ethernet100 
PORT         EVENT                          TIME
-----------  -----------------------------  ---------------------------
Ethernet100  linkmgrd_switch_standby_start  2022-Oct-06 23:41:20.023126
Ethernet100  orch_switch_standby_start      2022-Oct-06 23:41:20.024741
Ethernet100  orch_switch_standby_end        2022-Oct-06 23:41:20.027517
Ethernet100  xcvrd_switch_standby_start     2022-Oct-06 23:41:20.034635
Ethernet100  xcvrd_switch_standby_end       2022-Oct-06 23:41:20.090085
Ethernet100  linkmgrd_switch_standby_end    2022-Oct-06 23:41:20.091313
```

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->