### PR TITLE
[active-active] Fix config reload

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -663,6 +663,9 @@ void ActiveActiveStateMachine::LinkProberActiveMuxActiveLinkUpTransitionFunction
         switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
     } else if (ms(mCompositeState) != mux_state::MuxState::Active) {
         switchMuxState(nextState, mux_state::MuxState::Label::Active);
+    } else if (mLastMuxStateNotification == mux_state::MuxState::Label::Unknown) {
+        // switch active to notify swss
+        switchMuxState(nextState, mux_state::MuxState::Label::Active);
     }
 }
 

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -235,21 +235,6 @@ void LinkManagerStateMachineActiveActiveTest::postPckLossCountsResetEvent()
     runIoService(4);
 }
 
-TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceRepeatedMuxUnkown)
-{
-    // This unit test needs to run before any execution activatestateMachine();
-    VALIDATE_STATE(Wait, Wait, Down);
-    uint32_t probeForwardingStateBefore = mDbInterfacePtr->mProbeForwardingStateInvokeCount;
-
-    handleMuxState("unknown", 2);
-    VALIDATE_STATE(Wait, Wait, Down);
-    EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, probeForwardingStateBefore + 1);
-
-    handleProbeMuxState ("unknown", 1);
-    VALIDATE_STATE(Wait, Wait, Down);
-    EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, probeForwardingStateBefore + 2);
-}
-
 void LinkManagerStateMachineActiveActiveTest::setMuxActive()
 {
     activateStateMachine();
@@ -639,7 +624,7 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, GrpcTransientFailure)
     EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, 1);
 }
 
-TEST_F(LinkManagerStateMachineActiveActiveTest, PostPckLossMetricsEvent) 
+TEST_F(LinkManagerStateMachineActiveActiveTest, PostPckLossMetricsEvent)
 {
     setMuxActive();
 
@@ -657,7 +642,7 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, PostPckLossUpdateAndResetEvent)
     uint64_t unknownCount = 999;
     uint64_t totalCount = 10000;
 
-    postPckLossRatioUpdateEvent(unknownCount,totalCount);
+    postPckLossRatioUpdateEvent(unknownCount, totalCount);
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mIcmpUnknownEventCount, unknownCount);
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mIcmpPacketCount, totalCount);
     EXPECT_EQ(mDbInterfacePtr->mUnknownEventCount, unknownCount);
@@ -667,6 +652,59 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, PostPckLossUpdateAndResetEvent)
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mIcmpUnknownEventCount, 0);
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mIcmpPacketCount, 0);
     EXPECT_EQ(mDbInterfacePtr->mUnknownEventCount, 0);
-    EXPECT_EQ(mDbInterfacePtr->mExpectedPacketCount, 0);    
+    EXPECT_EQ(mDbInterfacePtr->mExpectedPacketCount, 0);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceRepeatedMuxUnkown)
+{
+    // This unit test needs to run before any execution activatestateMachine();
+    VALIDATE_STATE(Wait, Wait, Down);
+    uint32_t probeForwardingStateBefore = mDbInterfacePtr->mProbeForwardingStateInvokeCount;
+
+    handleMuxState("unknown", 2);
+    VALIDATE_STATE(Wait, Wait, Down);
+    EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, probeForwardingStateBefore + 1);
+
+    handleProbeMuxState("unknown", 1);
+    VALIDATE_STATE(Wait, Wait, Down);
+    EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, probeForwardingStateBefore + 2);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceMuxUnkown)
+{
+    // This unit test needs to run before any execution activatestateMachine();
+    VALIDATE_STATE(Wait, Wait, Down);
+    uint32_t probeForwardingStateBefore = mDbInterfacePtr->mProbeForwardingStateInvokeCount;
+
+    handleMuxState("unknown", 2);
+    VALIDATE_STATE(Wait, Wait, Down);
+    EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, probeForwardingStateBefore + 1);
+
+    handleProbeMuxState("unknown", 1);
+    VALIDATE_STATE(Wait, Wait, Down);
+    EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, probeForwardingStateBefore + 2);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceConfigReloadMuxUnknown)
+{
+    VALIDATE_STATE(Wait, Wait, Down);
+    uint32_t probeForwardingStateBefore = mDbInterfacePtr->mProbeForwardingStateInvokeCount;
+
+    handleMuxState("unknown", 2);
+    VALIDATE_STATE(Wait, Wait, Down);
+    EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, probeForwardingStateBefore + 1);
+
+    activateStateMachine();
+
+    postLinkEvent(link_state::LinkState::Up);
+    VALIDATE_STATE(Wait, Wait, Up);
+
+    handleProbeMuxState("active", 3);
+    VALIDATE_STATE(Wait, Active, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Active, 2);
+    VALIDATE_STATE(Active, Active, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
 }
 } /* namespace test */


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #144 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
After `config reload`, some ports `SERVER_STATUS` remain to be in `unknown`.

#### How did you do it?
Toggle to `active` again.

#### How did you verify/test it?
Add unittest to verify the boot sequence.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->