### PR TITLE
[active-active] Make `linkprober` susceptible to self negative events

### DIFF
--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -120,6 +120,22 @@ public:
     */
     inline void setNegativeStateChangeRetryCount(uint32_t stateChangeRetryCount) {
         mNegativeStateChangeRetryCount = stateChangeRetryCount;
+        // this is to ensure for the same amount of link prober self and peer
+        // events, self link prober state change could be triggered first
+        setPeerNegativeStateChangeRetryCount(2 * stateChangeRetryCount);
+    };
+
+    /**
+    *@method setPeerNegativeStateChangeRetryCount
+    *
+    *@brief setter for LinkProber peer negative state change retry count
+    *
+    *@param peerStateChangeRetryCount (in)  peer state change retry count
+    *
+    *@return none
+    */
+    inline void setPeerNegativeStateChangeRetryCount(uint32_t peerStateChangeRetryCount) {
+        mPeerNegativeStateChangeRetryCount = peerStateChangeRetryCount;
     };
 
     /**
@@ -243,6 +259,15 @@ public:
     *@return state change retry count
     */
     inline uint32_t getNegativeStateChangeRetryCount() const {return mNegativeStateChangeRetryCount;};
+
+    /**
+    *@method getPeerNegativeStateChangeRetryCount
+    *
+    *@brief getter for LinkProber peer negative state change retry count
+    *
+    *@return peer state change retry count
+    */
+    inline uint32_t getPeerNegativeStateChangeRetryCount() const {return mPeerNegativeStateChangeRetryCount;};
 
     /**
     *@method getSuspendTimeout_msec
@@ -389,6 +414,7 @@ private:
     uint32_t mTimeoutIpv6_msec = 1000;
     uint32_t mPositiveStateChangeRetryCount = 1;
     uint32_t mNegativeStateChangeRetryCount = 3;
+    uint32_t mPeerNegativeStateChangeRetryCount = mNegativeStateChangeRetryCount * 2;
     uint32_t mSuspendTimeout_msec = 500;
     uint32_t mMuxStateChangeRetryCount = 1;
     uint32_t mLinkStateChangeRetryCount = 1;

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -175,6 +175,15 @@ public:
     inline uint32_t getNegativeStateChangeRetryCount() const {return mMuxConfig.getNegativeStateChangeRetryCount();};
 
     /**
+    *@method getPeerNegativeStateChangeRetryCount
+    *
+    *@brief getter for LinkProber peer negative state change retry count
+    *
+    *@return peer state change retry count
+    */
+    inline uint32_t getPeerNegativeStateChangeRetryCount() const {return mMuxConfig.getPeerNegativeStateChangeRetryCount();};
+
+    /**
     *@method getSuspendTimeout_msec
     *
     *@brief getter for LinkProber suspend timer timeout

--- a/src/link_prober/PeerActiveState.cpp
+++ b/src/link_prober/PeerActiveState.cpp
@@ -60,10 +60,12 @@ LinkProberState* PeerActiveState::handleEvent(IcmpPeerActiveEvent &event)
 //
 LinkProberState* PeerActiveState::handleEvent(IcmpPeerUnknownEvent &event)
 {
+    MUXLOGDEBUG(getMuxPortConfig().getPortName());
+
     LinkProberStateMachineBase *stateMachine = dynamic_cast<LinkProberStateMachineBase *> (getStateMachine());
     LinkProberState *nextState;
 
-    if (++mUnknownEventCount >= getMuxPortConfig().getNegativeStateChangeRetryCount()) {
+    if (++mUnknownEventCount >= getMuxPortConfig().getPeerNegativeStateChangeRetryCount()) {
         nextState = dynamic_cast<LinkProberState *> (stateMachine->getPeerUnknownState());
     }
     else {

--- a/test/LinkManagerStateMachineActiveActiveTest.h
+++ b/test/LinkManagerStateMachineActiveActiveTest.h
@@ -34,7 +34,7 @@ public:
     void runIoService(uint32_t count = 0);
     void pollIoService(uint32_t count = 0);
     void postLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count = 0);
-    void postPeerLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count = 0);
+    void postPeerLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count = 0, uint32_t retry_count = 0);
     void postMuxEvent(mux_state::MuxState::Label label, uint32_t count = 0);
     void postLinkEvent(link_state::LinkState::Label label, uint32_t count = 0);
     void postSuspendTimerExpiredEvent(uint32_t count = 0);
@@ -50,6 +50,7 @@ public:
     const common::MuxPortConfig &getMuxPortConfig();
     void postPckLossRatioUpdateEvent(uint64_t unknownCount, uint64_t totalCount);
     void postPckLossCountsResetEvent();
+    inline common::MuxConfig &getMuxConfig() { return mMuxConfig; }
 
 public:
     boost::asio::io_service mIoService;

--- a/test/MockLinkProberTest.cpp
+++ b/test/MockLinkProberTest.cpp
@@ -179,6 +179,11 @@ TEST_F(LinkProberMockTest, LinkProberActiveActive)
     handleTimeout();
     runIoService();
 
+    sendHeartbeat();
+
+    handleTimeout();
+    runIoService();
+
     TearDown();
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #143 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
With the same amount of both self && peer link prober unknown events at the same time, `linkmgrd` might make two toggles: toggle peer to standby first, then toggle itself to standby. This will make the ToRs pair unreachable from the mux server.

#### How did you do it?
For peer link prober negative events, introduce a new retry threshold `MuxConfig::mPeerNegativeStateChangeRetryCount`, which is double as self link prober negative event retry threshold. So with the same amount of both self && peer link prober unknown events at the same time, `linkmgrd` will make only one self toggle to standby.

#### How did you verify/test it?
Add unittests.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->