### PR TITLE
[active-active] Add support to send/handle mux probe request

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -144,6 +144,9 @@ void ActiveActiveStateMachine::handleSwssSoCIpv4AddressUpdate(boost::asio::ip::a
             mResetIcmpPacketCountsFnPtr = boost::bind(
                 &link_prober::LinkProber::resetIcmpPacketCounts, mLinkProberPtr.get()
             );
+            mmSendPeerProbeCommandFnPtr = boost::bind(
+                &link_prober::LinkProber::sendPeerProbeCommand, mLinkProberPtr.get()
+            );
 
             setComponentInitState(LinkProberComponent);
 
@@ -536,6 +539,8 @@ void ActiveActiveStateMachine::handlePeerStateChange(
             case link_prober::LinkProberState::Label::PeerUnknown: {
                 if (mLabel == Label::Healthy) {
                     switchPeerMuxState(mux_state::MuxState::Label::Standby);
+                    // notify peer to probe for mux change
+                    mSendPeerProbeCommandFnPtr();
                 }
                 break;
             }

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -554,8 +554,6 @@ void ActiveActiveStateMachine::handlePeerStateChange(
             case link_prober::LinkProberState::Label::PeerUnknown: {
                 if (mLabel == Label::Healthy) {
                     switchPeerMuxState(mux_state::MuxState::Label::Standby);
-                    // notify peer to probe for mux change
-                    mSendPeerProbeCommandFnPtr();
                 }
                 break;
             }
@@ -937,6 +935,11 @@ void ActiveActiveStateMachine::switchPeerMuxState(mux_state::MuxState::Label lab
         enterPeerMuxState(label);
         mMuxPortPtr->setPeerMuxState(label);
         startPeerMuxWaitTimer();
+
+        if (label == mux_state::MuxState::Standby) {
+            // notify peer to probe for mux change
+            mSendPeerProbeCommandFnPtr();
+        }
     }
 }
 

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -934,12 +934,8 @@ void ActiveActiveStateMachine::switchPeerMuxState(mux_state::MuxState::Label lab
         );
         enterPeerMuxState(label);
         mMuxPortPtr->setPeerMuxState(label);
+        mLastSetPeerMuxState = label;
         startPeerMuxWaitTimer();
-
-        if (label == mux_state::MuxState::Standby) {
-            // notify peer to probe for mux change
-            mSendPeerProbeCommandFnPtr();
-        }
     }
 }
 
@@ -1140,6 +1136,12 @@ void ActiveActiveStateMachine::handlePeerMuxWaitTimeout(boost::system::error_cod
             "xcvrd timed out responding to linkmgrd peer mux state" %
             mMuxStateName[mPeerMuxState]
         );
+    }
+    if (mLastSetPeerMuxState == mux_state::MuxState::Label::Standby) {
+        // notify peer to probe mux because we had toggled peer to standby
+        // and this probe should be handled by the ycable after the toggle
+        // as we have waited for peer wait timeout.
+        mSendPeerProbeCommandFnPtr();
     }
 }
 

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -465,6 +465,24 @@ private: // utility methods to check/modify state
      */
     void initPeerLinkProberState();
 
+    /**
+     * @method startWaitMux
+     *
+     * @brief start waiting for mux, either mux set reply or probe reply
+     *
+     * @return none
+     */
+    inline void startWaitMux() { mWaitMux = true; }
+
+    /**
+     * @method stopWaitMux
+     *
+     * @brief stop waiting for mux, either mux set reply or probe reply
+     *
+     * @return none
+     */
+    inline void stopWaitMux() { mWaitMux = false; }
+
 private:
     /**
      * @brief start a mux probe and wait for mux probe notification(active or standby) from xcvrd
@@ -625,24 +643,6 @@ private: // testing only
      * @return none
      */
     void setSendPeerProbeCommandFnPtr(boost::function<void()> sendPeerProbeCommandFnPtr) { mSendPeerProbeCommandFnPtr = sendPeerProbeCommandFnPtr; }
-
-    /**
-     * @method startWaitMux
-     *
-     * @brief start waiting for mux, either mux set reply or probe reply
-     *
-     * @return none
-     */
-    inline void startWaitMux() { mWaitMux = true; }
-
-    /**
-     * @method stopWaitMux
-     *
-     * @brief stop waiting for mux, either mux set reply or probe reply
-     *
-     * @return none
-     */
-    inline void stopWaitMux() { mWaitMux = false; }
 
 private: // peer link prober state and mux state
     link_prober::LinkProberState::Label mPeerLinkProberState = link_prober::LinkProberState::Label::PeerWait;

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -647,6 +647,7 @@ private: // testing only
 private: // peer link prober state and mux state
     link_prober::LinkProberState::Label mPeerLinkProberState = link_prober::LinkProberState::Label::PeerWait;
     mux_state::MuxState::Label mPeerMuxState = mux_state::MuxState::Label::Wait;
+    mux_state::MuxState::Label mLastSetPeerMuxState = mux_state::MuxState::Label::Wait;
     mux_state::MuxState::Label mLastMuxStateNotification = mux_state::MuxState::Label::Unknown;
 
 private:

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -616,6 +616,17 @@ private: // testing only
     void setResetIcmpPacketCountsFnPtr(boost::function<void()> resetIcmpPacketCountsFnPtr) { mResetIcmpPacketCountsFnPtr = resetIcmpPacketCountsFnPtr; }
 
     /**
+     * @method set
+     *
+     * @brief set mSendPeerProbeCommandFnPtr. This method is used for testing
+     *
+     * @param sendPeerProbeCommandFnPtr (in)           pointer to new sendPeerProbeCommandFnPtr
+     *
+     * @return none
+     */
+    void setSendPeerProbeCommandFnPtr(boost::function<void()> sendPeerProbeCommandFnPtr) { mSendPeerProbeCommandFnPtr = sendPeerProbeCommandFnPtr; }
+
+    /**
      * @method startWaitMux
      *
      * @brief start waiting for mux, either mux set reply or probe reply

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -217,6 +217,15 @@ public: // link prober event handlers
      */
     void handleSuspendTimerExpiry() override;
 
+    /**
+     *@method handleMuxProbeRequestEvent
+     *
+     *@brief handle mux probe request from peer ToR
+     *
+     *@return none
+     */
+    void handleMuxProbeRequestEvent() override;
+
 public: // state handlers
     /**
      * @method handleStateChange
@@ -606,6 +615,24 @@ private: // testing only
      */
     void setResetIcmpPacketCountsFnPtr(boost::function<void()> resetIcmpPacketCountsFnPtr) { mResetIcmpPacketCountsFnPtr = resetIcmpPacketCountsFnPtr; }
 
+    /**
+     * @method startWaitMux
+     *
+     * @brief start waiting for mux, either mux set reply or probe reply
+     *
+     * @return none
+     */
+    inline void startWaitMux() { mWaitMux = true; }
+
+    /**
+     * @method stopWaitMux
+     *
+     * @brief stop waiting for mux, either mux set reply or probe reply
+     *
+     * @return none
+     */
+    inline void stopWaitMux() { mWaitMux = false; }
+
 private: // peer link prober state and mux state
     link_prober::LinkProberState::Label mPeerLinkProberState = link_prober::LinkProberState::Label::PeerWait;
     mux_state::MuxState::Label mPeerMuxState = mux_state::MuxState::Label::Wait;
@@ -614,6 +641,7 @@ private: // peer link prober state and mux state
 private:
     uint32_t mMuxProbeBackoffFactor = 1;
 
+    bool mWaitMux = false;
     boost::asio::deadline_timer mDeadlineTimer;
     boost::asio::deadline_timer mWaitTimer;
     boost::asio::deadline_timer mPeerWaitTimer;

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -626,6 +626,7 @@ private:
     boost::function<void()> mShutdownTxFnPtr;
     boost::function<void()> mRestartTxFnPtr;
     boost::function<void ()> mResetIcmpPacketCountsFnPtr;
+    boost::function<void ()> mSendPeerProbeCommandFnPtr;
 
     DefaultRoute mDefaultRouteState = DefaultRoute::Wait;
 

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -286,6 +286,17 @@ void LinkManagerStateMachineBase::handleSwitchActiveRequestEvent()
 }
 
 //
+// ---> handleMuxProbeRequestEvent();
+//
+// handle mux probe request from peer ToR
+//
+void LinkManagerStateMachineBase::handleMuxProbeRequestEvent()
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
+
+//
 // ---> handleDefaultRouteStateNotification(const DefaultRoute routeState);
 //
 // handle default route state notification from routeorch

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -465,6 +465,15 @@ public:
     virtual void handleSwitchActiveRequestEvent();
 
     /**
+     *@method handleMuxProbeRequestEvent
+     *
+     *@brief handle mux probe request from peer ToR
+     *
+     *@return none
+     */
+    virtual void handleMuxProbeRequestEvent();
+
+    /**
      * @method handleDefaultRouteStateNotification(const DefaultRoute routeState)
      *
      * @brief handle default route state notification from routeorch

--- a/src/link_prober/IcmpPayload.h
+++ b/src/link_prober/IcmpPayload.h
@@ -74,6 +74,7 @@ struct Tlv {
 enum class Command: uint8_t {
     COMMAND_NONE,
     COMMAND_SWITCH_ACTIVE,
+    COMMAND_MUX_PROBE,
 
     Count
 };

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -246,6 +246,17 @@ void LinkProber::sendPeerSwitchCommand()
 }
 
 //
+// ---> sendPeerProbeCommand();
+//
+// send send peer probe command
+//
+void LinkProber::sendPeerProbeCommand()
+{
+    boost::asio::io_service &ioService = mStrand.context();
+    ioService.post(mStrand.wrap(boost::bind(&LinkProber::handleSendProbeCommand, this)));
+}
+
+//
 // ---> handleUpdateEthernetFrame();
 //
 // update Ethernet frame of Tx Buffer
@@ -277,6 +288,20 @@ void LinkProber::handleSendSwitchCommand()
         mLinkProberStateMachinePtr,
         LinkProberStateMachineBase::getSwitchActiveCommandCompleteEvent()
     )));
+}
+
+//
+// ---> handleSendProbeCommand();
+//
+// send probe command to peer ToR
+//
+void LinkProber::handleSendProbeCommand()
+{
+    initTxBufferTlvSendProbe();
+
+    sendHeartbeat();
+
+    initTxBufferTlvSentinel();
 }
 
 //
@@ -759,6 +784,20 @@ void LinkProber::initTxBufferTlvSendSwitch()
 {
     resetTxBufferTlv();
     appendTlvCommand(Command::COMMAND_SWITCH_ACTIVE);
+    appendTlvSentinel();
+
+    calculateTxPacketChecksum();
+}
+
+//
+// ---> initTxBufferTlvSendProbe
+//
+// Initialize TX buffer TLVs to send probe command to peer
+//
+void LinkProber::initTxBufferTlvSendProbe()
+{
+    resetTxBufferTlv();
+    appendTlvCommand(Command::COMMAND_MUX_PROBE);
     appendTlvSentinel();
 
     calculateTxPacketChecksum();

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -248,7 +248,7 @@ void LinkProber::sendPeerSwitchCommand()
 //
 // ---> sendPeerProbeCommand();
 //
-// send send peer probe command
+// send peer probe command
 //
 void LinkProber::sendPeerProbeCommand()
 {

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -253,7 +253,7 @@ void LinkProber::sendPeerSwitchCommand()
 void LinkProber::sendPeerProbeCommand()
 {
     boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(&LinkProber::handleSendProbeCommand, this)));
+    boost::asio::post(mStrand, boost::bind(&LinkProber::handleSendProbeCommand, this));
 }
 
 //
@@ -344,19 +344,19 @@ void LinkProber::handleTlvCommandRecv(
 
         switch (static_cast<Command>(tlvPtr->command)) {
             case Command::COMMAND_SWITCH_ACTIVE: {
-                ioService.post(strand.wrap(boost::bind(
+                boost::asio::post(mStrand, boost::bind(
                     static_cast<void (LinkProberStateMachineBase::*) (SwitchActiveRequestEvent&)>(&LinkProberStateMachineBase::processEvent),
                     mLinkProberStateMachinePtr,
                     LinkProberStateMachineBase::getSwitchActiveRequestEvent()
-                )));
+                ));
                 break;
             }
             case Command::COMMAND_MUX_PROBE: {
-                ioService.post(strand.wrap(boost::bind(
+                boost::asio::post(mStrand, boost::bind(
                     static_cast<void (LinkProberStateMachineBase::*) (MuxProbeRequestEvent&)>(&LinkProberStateMachineBase::processEvent),
                     mLinkProberStateMachinePtr,
                     LinkProberStateMachineBase::getMuxProbeRequestEvent()
-                )));
+                ));
                 break;
             }
             default: {

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -339,15 +339,29 @@ void LinkProber::handleTlvCommandRecv(
 )
 {
     if (isPeer) {
-        if (tlvPtr->command == static_cast<uint8_t> (Command::COMMAND_SWITCH_ACTIVE)) {
-            boost::asio::io_service::strand &strand = mLinkProberStateMachinePtr->getStrand();
-            boost::asio::io_service &ioService = strand.context();
-            ioService.post(strand.wrap(boost::bind(
-                static_cast<void (LinkProberStateMachineBase::*) (SwitchActiveRequestEvent&)>
-                    (&LinkProberStateMachineBase::processEvent),
-                mLinkProberStateMachinePtr,
-                LinkProberStateMachineBase::getSwitchActiveRequestEvent()
-            )));
+        boost::asio::io_service::strand &strand = mLinkProberStateMachinePtr->getStrand();
+        boost::asio::io_service &ioService = strand.context();
+
+        switch (static_cast<Command>(tlvPtr->command)) {
+            case Command::COMMAND_SWITCH_ACTIVE: {
+                ioService.post(strand.wrap(boost::bind(
+                    static_cast<void (LinkProberStateMachineBase::*) (SwitchActiveRequestEvent&)>(&LinkProberStateMachineBase::processEvent),
+                    mLinkProberStateMachinePtr,
+                    LinkProberStateMachineBase::getSwitchActiveRequestEvent()
+                )));
+                break;
+            }
+            case Command::COMMAND_MUX_PROBE: {
+                ioService.post(strand.wrap(boost::bind(
+                    static_cast<void (LinkProberStateMachineBase::*) (MuxProbeRequestEvent&)>(&LinkProberStateMachineBase::processEvent),
+                    mLinkProberStateMachinePtr,
+                    LinkProberStateMachineBase::getMuxProbeRequestEvent()
+                )));
+                break;
+            }
+            default: {
+                break;
+            }
         }
     }
 }

--- a/src/link_prober/LinkProber.h
+++ b/src/link_prober/LinkProber.h
@@ -176,6 +176,15 @@ public:
     void sendPeerSwitchCommand();
 
     /**
+    *@method sendPeerProbeCommand
+    *
+    *@brief send probe command to peer ToR
+    *
+    *@return none
+    */
+    void sendPeerProbeCommand();
+
+    /**
      * @method resetIcmpPacketCounts()
      * 
      * @brief reset Icmp packet counts, post a pck loss ratio update immediately 
@@ -241,6 +250,15 @@ private:
     *@return none
     */
     void handleSendSwitchCommand();
+
+    /**
+    *@method handleSendProbeCommand
+    *
+    *@brief send probe command to peer ToR
+    *
+    *@return none
+    */
+    void handleSendProbeCommand();
 
     /**
     *@method sendHeartbeat
@@ -464,13 +482,22 @@ private:
     size_t appendTlvDummy(size_t paddingSize, int seqNo);
 
     /**
-     * @method initTlvSendSwitch
+     * @method initTxBufferTlvSendSwitch
      * 
      * @brief initialize TX buffer TLVs to send switch command to peer
      * 
      * @return none
      */
     void initTxBufferTlvSendSwitch();
+
+    /**
+     * @method initTxBufferTlvSendProbe
+     *
+     * @brief initialize TX buffer TLVs to send probe command to peer
+     *
+     * @return none
+     */
+    void initTxBufferTlvSendProbe();
 
     /**
      * @method initTxBufferTlvSentinel

--- a/src/link_prober/LinkProberStateMachineActiveActive.cpp
+++ b/src/link_prober/LinkProberStateMachineActiveActive.cpp
@@ -180,6 +180,22 @@ void LinkProberStateMachineActiveActive::processEvent(SuspendTimerExpiredEvent &
 }
 
 //
+// ---> processEvent(MuxProbeRequestEvent &muxProbeRequestEvent);
+//
+// process LinkProberState mux probe request event
+//
+void LinkProberStateMachineActiveActive::processEvent(MuxProbeRequestEvent &muxProbeRequestEvent)
+{
+    boost::asio::io_service::strand &strand = mLinkManagerStateMachinePtr->getStrand();
+    boost::asio::io_service &ioService = strand.context();
+    ioService.post(strand.wrap(boost::bind(
+        &link_manager::LinkManagerStateMachineBase::handleMuxProbeRequestEvent,
+        mLinkManagerStateMachinePtr
+    )));
+}
+
+
+//
 // ---> postLinkManagerPeerEvent(LinkProberState* linkProberState);
 //
 // post LinkProberState peer change event to LinkManager state machine

--- a/src/link_prober/LinkProberStateMachineActiveActive.cpp
+++ b/src/link_prober/LinkProberStateMachineActiveActive.cpp
@@ -188,10 +188,10 @@ void LinkProberStateMachineActiveActive::processEvent(MuxProbeRequestEvent &muxP
 {
     boost::asio::io_service::strand &strand = mLinkManagerStateMachinePtr->getStrand();
     boost::asio::io_service &ioService = strand.context();
-    ioService.post(strand.wrap(boost::bind(
+    boost::asio::post(mStrand, boost::bind(
         &link_manager::LinkManagerStateMachineBase::handleMuxProbeRequestEvent,
         mLinkManagerStateMachinePtr
-    )));
+    ));
 }
 
 

--- a/src/link_prober/LinkProberStateMachineActiveActive.h
+++ b/src/link_prober/LinkProberStateMachineActiveActive.h
@@ -119,6 +119,17 @@ public:
     void processEvent(SuspendTimerExpiredEvent &suspendTimerExpiredEvent) override;
 
     /**
+     *@method processEvent
+     *
+     *@brief process MuxProbeRequestEvent
+     *
+     *@param muxProbeRequestEvent (in)  reference to the MuxProbeRequestEvent event
+     *
+     *@return none
+     */
+    void processEvent(MuxProbeRequestEvent &muxProbeRequestEvent) override;
+
+    /**
      *@method getCurrentPeerState
      *
      *@brief getter for current peer state

--- a/src/link_prober/LinkProberStateMachineBase.cpp
+++ b/src/link_prober/LinkProberStateMachineBase.cpp
@@ -33,6 +33,7 @@ IcmpUnknownEvent LinkProberStateMachineBase::mIcmpUnknownEvent;
 SuspendTimerExpiredEvent LinkProberStateMachineBase::mSuspendTimerExpiredEvent;
 SwitchActiveCommandCompleteEvent LinkProberStateMachineBase::mSwitchActiveCommandCompleteEvent;
 SwitchActiveRequestEvent LinkProberStateMachineBase::mSwitchActiveRequestEvent;
+MuxProbeRequestEvent LinkProberStateMachineBase::mMuxProbeRequestEvent;
 IcmpPeerActiveEvent LinkProberStateMachineBase::mIcmpPeerActiveEvent;
 IcmpPeerUnknownEvent LinkProberStateMachineBase::mIcmpPeerUnknownEvent;
 
@@ -209,6 +210,17 @@ void LinkProberStateMachineBase::processEvent(SwitchActiveRequestEvent &switchAc
 {
     MUXLOGDEBUG(mMuxPortConfig.getPortName());
 }
+
+//
+// ---> processEvent(MuxProbeRequestEvent &muxProbeRequestEvent);
+//
+// process LinkProberState mux probe request event
+//
+void LinkProberStateMachineBase::processEvent(MuxProbeRequestEvent &muxProbeRequestEvent)
+{
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+}
+
 
 //
 // ---> handleMackAddressUpdate(const std::array<uint8_t, ETHER_ADDR_LEN> address);

--- a/src/link_prober/LinkProberStateMachineBase.h
+++ b/src/link_prober/LinkProberStateMachineBase.h
@@ -128,6 +128,18 @@ public:
     ~SwitchActiveRequestEvent() = default;
 };
 
+/**
+ *@class MuxProbeRequestEvent
+ *
+ *@brief signals a MuxProbeRequestEvent event to LinkProber state machine
+ */
+class MuxProbeRequestEvent
+{
+public:
+    MuxProbeRequestEvent() = default;
+    ~MuxProbeRequestEvent() = default;
+};
+
 class LinkProberStateMachineActiveStandby;
 class LinkProberStateMachineActiveActive;
 
@@ -267,6 +279,17 @@ public:
      *@return none
      */
     virtual void processEvent(SwitchActiveRequestEvent &switchActiveRequestEvent);
+
+    /**
+     *@method processEvent
+     *
+     *@brief process LinkProberState mux probe request
+     *
+     *@param muxProbeRequestEvent (in)  reference to the MuxProbeRequestEvent event
+     *
+     *@return none
+     */
+    virtual void processEvent(MuxProbeRequestEvent &muxProbeRequestEvent);
 
     /**
      *@method handleMackAddressUpdate
@@ -432,6 +455,15 @@ public:
     static SwitchActiveRequestEvent &getSwitchActiveRequestEvent() { return mSwitchActiveRequestEvent; };
 
     /**
+     *@method getMuxProbeRequestEvent
+     *
+     *@brief getter for MuxProbeRequestEvent object
+     *
+     *@return pointer to MuxProbeRequestEvent object
+     */
+    static MuxProbeRequestEvent &getMuxProbeRequestEvent() { return mMuxProbeRequestEvent; };
+
+    /**
      *@method getIcmpPeerActiveEvent
      *
      *@brief getter for IcmpPeerActiveEvent object
@@ -468,6 +500,7 @@ private:
     static SuspendTimerExpiredEvent mSuspendTimerExpiredEvent;
     static SwitchActiveCommandCompleteEvent mSwitchActiveCommandCompleteEvent;
     static SwitchActiveRequestEvent mSwitchActiveRequestEvent;
+    static MuxProbeRequestEvent mMuxProbeRequestEvent;
     static IcmpPeerActiveEvent mIcmpPeerActiveEvent;
     static IcmpPeerUnknownEvent mIcmpPeerUnknownEvent;
 

--- a/test/FakeLinkProber.cpp
+++ b/test/FakeLinkProber.cpp
@@ -126,6 +126,13 @@ void FakeLinkProber::sendPeerSwitchCommand()
     mSendPeerSwitchCommand++;
 }
 
+void FakeLinkProber::sendPeerProbeCommand()
+{
+    MUXLOGINFO("");
+
+    mSendPeerProbeCommand++;
+}
+
 void FakeLinkProber::handleSendSwitchCommand()
 {
     // inform the composite state machine about command send completion
@@ -148,6 +155,18 @@ void FakeLinkProber::handleSwitchCommandRecv()
             (&link_prober::LinkProberStateMachineBase::processEvent),
         mLinkProberStateMachine,
         link_prober::LinkProberStateMachineBase::getSwitchActiveRequestEvent()
+    )));
+}
+
+void FakeLinkProber::handleMuxProbeCommandRecv()
+{
+    boost::asio::io_service::strand& strand = mLinkProberStateMachine->getStrand();
+    boost::asio::io_service &ioService = strand.context();
+    ioService.post(strand.wrap(boost::bind(
+        static_cast<void (link_prober::LinkProberStateMachineBase::*) (link_prober::MuxProbeRequestEvent&)>
+            (&link_prober::LinkProberStateMachineBase::processEvent),
+        mLinkProberStateMachine,
+        link_prober::LinkProberStateMachineBase::getMuxProbeRequestEvent()
     )));
 }
 

--- a/test/FakeLinkProber.cpp
+++ b/test/FakeLinkProber.cpp
@@ -162,12 +162,12 @@ void FakeLinkProber::handleMuxProbeCommandRecv()
 {
     boost::asio::io_service::strand& strand = mLinkProberStateMachine->getStrand();
     boost::asio::io_service &ioService = strand.context();
-    ioService.post(strand.wrap(boost::bind(
+    boost::asio::post(strand, boost::bind(
         static_cast<void (link_prober::LinkProberStateMachineBase::*) (link_prober::MuxProbeRequestEvent&)>
             (&link_prober::LinkProberStateMachineBase::processEvent),
         mLinkProberStateMachine,
         link_prober::LinkProberStateMachineBase::getMuxProbeRequestEvent()
-    )));
+    ));
 }
 
 void FakeLinkProber::resetIcmpPacketCounts()

--- a/test/FakeLinkProber.h
+++ b/test/FakeLinkProber.h
@@ -46,6 +46,7 @@ public:
     void suspendTxProbes(uint32_t suspendTime_msec);
     void resumeTxProbes();
     void sendPeerSwitchCommand();
+    void sendPeerProbeCommand();
     void resetIcmpPacketCounts();
     void shutdownTxProbes();
     void restartTxProbes();
@@ -53,8 +54,7 @@ public:
     void revertProbeIntervalAfterSwitchComplete();
     void handleSendSwitchCommand();
     void handleSwitchCommandRecv();
-
-
+    void handleMuxProbeCommandRecv();
 
 public:
     uint32_t mInitializeCallCount = 0;
@@ -64,6 +64,7 @@ public:
     uint32_t mSuspendTxProbeCallCount = 0;
     uint32_t mResumeTxProbeCallCount = 0;
     uint32_t mSendPeerSwitchCommand = 0;
+    uint32_t mSendPeerProbeCommand = 0;
     uint32_t mShutdownTxProbeCallCount = 0;
     uint32_t mRestartTxProbeCallCount = 0;
 

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -98,6 +98,9 @@ inline void FakeMuxPort::initLinkProberActiveActive()
     getActiveActiveStateMachinePtr()->setResetIcmpPacketCountsFnPtr(
         boost::bind(&FakeLinkProber::resetIcmpPacketCounts, mFakeLinkProber.get())
     );
+    getActiveActiveStateMachinePtr()->setSendPeerProbeCommandFnPtr(
+        boost::bind(&FakeLinkProber::sendPeerProbeCommand, mFakeLinkProber.get())
+    );
 }
 
 inline void FakeMuxPort::initLinkProberActiveStandby()

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -376,11 +376,11 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveLinkProberPeerUnknown)
     postPeerLinkProberEvent(link_prober::LinkProberState::PeerUnknown, 3);
     VALIDATE_PEER_STATE(PeerUnknown, Standby);
     EXPECT_EQ(mDbInterfacePtr->mSetPeerMuxStateInvokeCount, 1);
-    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSendPeerProbeCommand, 1);
     EXPECT_EQ(mDbInterfacePtr->mLastSetPeerMuxState, mux_state::MuxState::Label::Standby);
 
     handlePeerMuxState("standby", 1);
     VALIDATE_PEER_STATE(PeerUnknown, Standby);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSendPeerProbeCommand, 1);
 }
 
 TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveConfigDetachedLinkProberPeerUnknown)

--- a/test/LinkProberTest.cpp
+++ b/test/LinkProberTest.cpp
@@ -148,6 +148,26 @@ TEST_F(LinkProberTest, handleSendSwitchCommand)
     EXPECT_TRUE(icmpHeader->checksum == 12100);
 }
 
+TEST_F(LinkProberTest, handleSendProbeCommand)
+{
+    initializeSendBuffer();
+
+    iphdr *ipHeader = reinterpret_cast<iphdr *>(getTxBufferData() + sizeof(ether_header));
+    icmphdr *icmpHeader = reinterpret_cast<icmphdr *>(getTxBufferData() + sizeof(ether_header) + sizeof(iphdr));
+    ipHeader->id = static_cast<uint16_t> (17767);
+    initTxBufferSentinel();
+    EXPECT_TRUE(ipHeader->check == 62919);
+    EXPECT_TRUE(icmpHeader->checksum == 12100);
+
+    initTxBufferTlvSendProbe();
+    EXPECT_TRUE(ipHeader->check == 61895);
+    EXPECT_TRUE(icmpHeader->checksum == 11582);
+
+    initTxBufferSentinel();
+    EXPECT_TRUE(ipHeader->check == 62919);
+    EXPECT_TRUE(icmpHeader->checksum == 12100);
+}
+
 TEST_F(LinkProberTest, UpdateEthernetFrame)
 {
     link_prober::IcmpPayload *icmpPayload = new (

--- a/test/LinkProberTest.h
+++ b/test/LinkProberTest.h
@@ -58,6 +58,7 @@ public:
     uint16_t getRxPeerSeqNo() {return mLinkProber.mRxPeerSeqNo;};
     bool getSuspendTx() {return mLinkProber.mSuspendTx;};
     void initTxBufferTlvSendSwitch() {mLinkProber.initTxBufferTlvSendSwitch();}
+    void initTxBufferTlvSendProbe() {mLinkProber.initTxBufferTlvSendProbe();}
     void initTxBufferSentinel() {mLinkProber.initTxBufferTlvSentinel();}
 
     boost::asio::io_service mIoService;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #143

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
For issue #143, if there is a link drop for upstream traffic, the ToR will try to toggle both itself and peer to `standby`. But the peer ToR might still be able to receive heartbeats and should be in `active` state.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Enable `linkmgrd` to support sending mux probe command to its peer when it tries to toggle peer to `standby`.

#### How did you verify/test it?
Add unittests and verify on real dualtor pairs.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->