### PR TITLE
[Active-Active] periodically re-sync soc side admin forwarding state 

### DIFF
--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -378,6 +378,15 @@ public:
      */
     inline bool ifEnableUseTorMac() {return mMuxConfig.getIfEnableUseTorMac();};
 
+    /**
+     * @method getAdminForwardingStateSyncUpInterval
+     * 
+     * @brief getter of admin forwarding state sync up interval
+     * 
+     * @return sync up interval in msec
+     */
+    uint32_t getAdminForwardingStateSyncUpInterval() {return mAdminForwardingStateSyncUpInterval_msec;};
+
 private:
     MuxConfig &mMuxConfig;
     std::string mPortName;
@@ -388,6 +397,7 @@ private:
     uint16_t mServerId;
     Mode mMode = Manual;
     PortCableType mPortCableType;
+    uint32_t mAdminForwardingStateSyncUpInterval_msec = 10000;
 
 };
 

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -404,11 +404,11 @@ void ActiveActiveStateMachine::handleUseWellKnownMacAddressNotification()
 void ActiveActiveStateMachine::startAdminForwardingStateSyncUpTimer()
 {
     MUXLOGWARNING(mMuxPortConfig.getPortName());
-    mResyncTimer.expire_from_now(boost::posix_timer::milliseconds(
+    mResyncTimer.expires_from_now(boost::posix_time::milliseconds(
         mMuxPortConfig.getAdminForwardingStateSyncUpInterval()
     ));
     mResyncTimer.async_wait(boost::asio::bind_executor(getStrand(),             // wrap() is deprecated, using bind_executor()
-        std::bind(&ActiveActiveStateMachine::handleAdminForwardingStateSyncUp,  // https://www.boost.org/doc/libs/1_79_0/doc/html/boost_asio/reference/io_context__strand/wrap.html
+        boost::bind(&ActiveActiveStateMachine::handleAdminForwardingStateSyncUp,  // https://www.boost.org/doc/libs/1_79_0/doc/html/boost_asio/reference/io_context__strand/wrap.html
             this,
             boost::asio::placeholders::error
     )));

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -326,7 +326,7 @@ void ActiveActiveStateMachine::handleProbeMuxFailure()
 //
 void ActiveActiveStateMachine::handlePeerMuxStateNotification(mux_state::MuxState::Label label)
 {
-    MUXLOGWARNING(boost::format("%s: state db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
+    MUXLOGWARNING(boost::format("%s: app/state db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
 
     mPeerWaitTimer.cancel();
     enterPeerMuxState(label);
@@ -403,7 +403,7 @@ void ActiveActiveStateMachine::handleUseWellKnownMacAddressNotification()
 ---------------------------------------------------------------------------------------------------------------*/
 void ActiveActiveStateMachine::startAdminForwardingStateSyncUpTimer()
 {
-    MUXLOGWARNING(mMuxPortConfig.getPortName());
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
     mResyncTimer.expires_from_now(boost::posix_time::milliseconds(
         mMuxPortConfig.getAdminForwardingStateSyncUpInterval()
     ));
@@ -416,7 +416,7 @@ void ActiveActiveStateMachine::startAdminForwardingStateSyncUpTimer()
 
 void ActiveActiveStateMachine::handleAdminForwardingStateSyncUp(boost::system::error_code errorCode)
 {
-    MUXLOGWARNING(mMuxPortConfig.getPortName());
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
 
     if (!mWaitMux) 
     {

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -50,7 +50,8 @@ ActiveActiveStateMachine::ActiveActiveStateMachine(
       ),
       mDeadlineTimer(strand.context()),
       mWaitTimer(strand.context()),
-      mPeerWaitTimer(strand.context())
+      mPeerWaitTimer(strand.context()),
+      mResyncTimer(strand.context())
 {
     assert(muxPortPtr != nullptr);
     mMuxPortPtr->setMuxLinkmgrState(mLabel);
@@ -93,6 +94,8 @@ void ActiveActiveStateMachine::activateStateMachine()
         mStartProbingFnPtr();
 
         updateMuxLinkmgrState();
+
+        startAdminForwardingStateSyncUpTimer();
     }
 }
 
@@ -393,6 +396,34 @@ void ActiveActiveStateMachine::handleUseWellKnownMacAddressNotification()
             mComponentInitState.test(LinkProberComponent)
         );
     }
+}
+
+/*--------------------------------------------------------------------------------------------------------------
+|  soc side admin forwarding state re-sync
+---------------------------------------------------------------------------------------------------------------*/
+void ActiveActiveStateMachine::startAdminForwardingStateSyncUpTimer()
+{
+    MUXLOGWARNING(mMuxPortConfig.getPortName());
+    mResyncTimer.expire_from_now(boost::posix_timer::milliseconds(
+        mMuxPortConfig.getAdminForwardingStateSyncUpInterval()
+    ));
+    mResyncTimer.async_wait(boost::asio::bind_executor(getStrand(),             // wrap() is deprecated, using bind_executor()
+        std::bind(&ActiveActiveStateMachine::handleAdminForwardingStateSyncUp,  // https://www.boost.org/doc/libs/1_79_0/doc/html/boost_asio/reference/io_context__strand/wrap.html
+            this,
+            boost::asio::placeholders::error
+    )));
+}
+
+void ActiveActiveStateMachine::handleAdminForwardingStateSyncUp(boost::system::error_code errorCode)
+{
+    MUXLOGWARNING(mMuxPortConfig.getPortName());
+
+    if (!mWaitMux) 
+    {
+        probeMuxState();
+    }
+
+    startAdminForwardingStateSyncUpTimer();
 }
 
 /*--------------------------------------------------------------------------------------------------------------

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -542,15 +542,6 @@ private:
     void shutdownOrRestartLinkProberOnDefaultRoute() override;
 
     /**
-     * @method startAdminFowardingStateSyncUpTimer
-     * 
-     * @brief start admin forwarding state sync up timer
-     * 
-     * @return none
-     */
-    void startAdminForwardingStateSyncUpTimer();
-
-    /**
      * @method handleAdminFowardingStateSyncUp
      * 
      * @brief handle admin forwarding state sync up
@@ -559,6 +550,15 @@ private:
      */
     void handleAdminForwardingStateSyncUp(boost::system::error_code errorCode);
 
+public: 
+    /**
+     * @method startAdminFowardingStateSyncUpTimer
+     * 
+     * @brief start admin forwarding state sync up timer
+     * 
+     * @return none
+     */
+    void startAdminForwardingStateSyncUpTimer();
 
 private: // testing only
     friend class mux::MuxPort;

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -541,6 +541,25 @@ private:
      */
     void shutdownOrRestartLinkProberOnDefaultRoute() override;
 
+    /**
+     * @method startAdminFowardingStateSyncUpTimer
+     * 
+     * @brief start admin forwarding state sync up timer
+     * 
+     * @return none
+     */
+    void startAdminForwardingStateSyncUpTimer();
+
+    /**
+     * @method handleAdminFowardingStateSyncUp
+     * 
+     * @brief handle admin forwarding state sync up
+     * 
+     * @return none
+     */
+    void handleAdminForwardingStateSyncUp(boost::system::error_code errorCode);
+
+
 private: // testing only
     friend class mux::MuxPort;
     friend class test::FakeMuxPort;
@@ -657,6 +676,7 @@ private:
     boost::asio::deadline_timer mDeadlineTimer;
     boost::asio::deadline_timer mWaitTimer;
     boost::asio::deadline_timer mPeerWaitTimer;
+    boost::asio::deadline_timer mResyncTimer;
 
     boost::function<void()> mInitializeProberFnPtr;
     boost::function<void()> mStartProbingFnPtr;

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -769,4 +769,23 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveLinkProberUnknownRecvMu
     VALIDATE_STATE(Unknown, Standby, Up);
 }
 
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActivePeriodicalCheck)
+{
+    setMuxActive();
+
+    uint32_t probeForwardingStateBefore = mDbInterfacePtr->mProbeForwardingStateInvokeCount;
+    uint32_t setForwardingStateBefore = mDbInterfacePtr->mSetMuxStateInvokeCount;
+
+    mFakeMuxPort.getActiveActiveStateMachinePtr()->startAdminForwardingStateSyncUpTimer();
+    sleep(10);
+    runIoService(3);
+    EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, probeForwardingStateBefore + 1);
+
+    handleProbeMuxState("standby", 4);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, setForwardingStateBefore + 1);
+
+    handleMuxState("active", 2);
+    VALIDATE_STATE(Active, Active, Up);
+}
+
 } /* namespace test */


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to help recover when SoC side admin forwarding state is unexpectedly changed. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
When server side admin forwarding state is different from ToR side, we want to correct it back. 

#### How did you do it?
Start a periodical update since state machine is activated. 

#### How did you verify/test it?
Tested on DUTs. RPC was called for getting every 10 seconds. 
```
Oct 31 23:38:52.708151 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:406 startAdminForwardingStateSyncUpTimer: Ethernet12
Oct 31 23:39:02.708674 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:419 handleAdminForwardingStateSyncUp: Ethernet12
Oct 31 23:39:02.708924 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:406 startAdminForwardingStateSyncUpTimer: Ethernet12
Oct 31 23:39:02.735442 svcstr-7050-acs-1 NOTICE pmon#ycable[35]: calling RPC for getting forwarding state port = Ethernet12 portid 1 peer portid 0 read_side 1
Oct 31 23:39:02.737913 svcstr-7050-acs-1 NOTICE pmon#ycable[35]: forwarding state RPC received response port = Ethernet12 portids [0, 1] read_side 1
Oct 31 23:39:02.737913 svcstr-7050-acs-1 NOTICE pmon#ycable[35]: forwarding state RPC received response port = Ethernet12 state values = [True, True] read_side 1
Oct 31 23:39:02.740029 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:263 handleProbeMuxStateNotification: Ethernet12: app db mux state: Active
Oct 31 23:39:02.740892 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:329 handlePeerMuxStateNotification: Ethernet12: state db mux state: Active
Oct 31 23:39:12.708058 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:419 handleAdminForwardingStateSyncUp: Ethernet12
Oct 31 23:39:12.708131 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:406 startAdminForwardingStateSyncUpTimer: Ethernet12
Oct 31 23:39:12.738711 svcstr-7050-acs-1 NOTICE pmon#ycable[35]: calling RPC for getting forwarding state port = Ethernet12 portid 1 peer portid 0 read_side 1
Oct 31 23:39:12.740990 svcstr-7050-acs-1 NOTICE pmon#ycable[35]: forwarding state RPC received response port = Ethernet12 portids [0, 1] read_side 1
Oct 31 23:39:12.740990 svcstr-7050-acs-1 NOTICE pmon#ycable[35]: forwarding state RPC received response port = Ethernet12 state values = [True, True] read_side 1
Oct 31 23:39:12.741667 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:263 handleProbeMuxStateNotification: Ethernet12: app db mux state: Active
Oct 31 23:39:12.741834 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:329 handlePeerMuxStateNotification: Ethernet12: state db mux state: Active
Oct 31 23:39:22.707953 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:419 handleAdminForwardingStateSyncUp: Ethernet12
Oct 31 23:39:22.708124 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:406 startAdminForwardingStateSyncUpTimer: Ethernet12
Oct 31 23:39:22.713332 svcstr-7050-acs-1 NOTICE pmon#ycable[35]: calling RPC for getting forwarding state port = Ethernet12 portid 1 peer portid 0 read_side 1
Oct 31 23:39:22.715236 svcstr-7050-acs-1 NOTICE pmon#ycable[35]: forwarding state RPC received response port = Ethernet12 portids [0, 1] read_side 1
Oct 31 23:39:22.715236 svcstr-7050-acs-1 NOTICE pmon#ycable[35]: forwarding state RPC received response port = Ethernet12 state values = [True, True] read_side 1
Oct 31 23:39:22.715873 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:263 handleProbeMuxStateNotification: Ethernet12: app db mux state: Active
Oct 31 23:39:22.715873 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:329 handlePeerMuxStateNotification: Ethernet12: state db mux state: Active
Oct 31 23:39:32.708199 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:419 handleAdminForwardingStateSyncUp: Ethernet12
Oct 31 23:39:32.708247 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:406 startAdminForwardingStateSyncUpTimer: Ethernet12
Oct 31 23:39:32.718781 svcstr-7050-acs-1 NOTICE pmon#ycable[35]: calling RPC for getting forwarding state port = Ethernet12 portid 1 peer portid 0 read_side 1
Oct 31 23:39:32.720327 svcstr-7050-acs-1 NOTICE pmon#ycable[35]: forwarding state RPC received response port = Ethernet12 portids [0, 1] read_side 1
Oct 31 23:39:32.720327 svcstr-7050-acs-1 NOTICE pmon#ycable[35]: forwarding state RPC received response port = Ethernet12 state values = [True, True] read_side 1
Oct 31 23:39:32.721021 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:263 handleProbeMuxStateNotification: Ethernet12: app db mux state: Active
Oct 31 23:39:32.721188 svcstr-7050-acs-1 WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:329 handlePeerMuxStateNotification: Ethernet12: state db mux state: Active
```

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->