### PR TITLE
[active-standby][active-active] update link prober stats updating frequency to 30s

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -1005,6 +1005,8 @@ void DbInterface::processMuxLinkmgrConfigNotifiction(std::deque<swss::KeyOpField
                         mMuxManagerPtr->setUseWellKnownMacActiveActive(v == "enable");
                     } else if (f == "src_mac") {
                         mMuxManagerPtr->processSrcMac(v == "ToRMac");
+                    } else if (f == "interval_pck_loss_count_update") {
+                        mMuxManagerPtr->setLinkProberStatUpdateIntervalCount(boost::lexical_cast<uint32_t> (v));
                     }
 
                     MUXLOGINFO(boost::format("key: %s, Operation: %s, f: %s, v: %s") %

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -123,6 +123,17 @@ public:
     inline void setTimeoutIpv6_msec(uint32_t timeout_msec) {mMuxConfig.setTimeoutIpv6_msec(timeout_msec);};
 
     /**
+    *@method setLinkProberStatUpdateIntervalCount
+    *
+    *@brief setter for link prober stats posting interval
+    *
+    *@param interval_count (in)  interval in heartbeat count
+    *
+    *@return none
+    */
+    inline void setLinkProberStatUpdateIntervalCount(uint32_t interval_count) {mMuxConfig.setLinkProberStatUpdateIntervalCount(interval_count);};
+
+    /**
     *@method setPositiveStateChangeRetryCount
     *
     *@brief setter for LinkProber positive state change retry count

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -97,6 +97,17 @@ public:
     inline void setTimeoutIpv6_msec(uint32_t timeout_msec) {mTimeoutIpv6_msec = timeout_msec;};
 
     /**
+    *@method setLinkProberStatUpdateIntervalCount
+    *
+    *@brief setter for link prober stats posting interval
+    *
+    *@param interval_count (in)  interval in heartbeat count
+    *
+    *@return none
+    */
+    inline void setLinkProberStatUpdateIntervalCount(uint32_t interval_count) {mLinkProberStatUpdateIntervalCount = interval_count > 50? interval_count:50;};
+
+    /**
     *@method setPositiveStateChangeRetryCount
     *
     *@brief setter for LinkProber positive state change retry count

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -245,6 +245,15 @@ public:
     inline uint32_t getNegativeStateChangeRetryCount() const {return mNegativeStateChangeRetryCount;};
 
     /**
+    *@method getLinkProberStatUpdateIntervalCount
+    *
+    *@brief getter for LinkProber negative state change retry count
+    *
+    *@return state change retry count
+    */
+    inline uint32_t getLinkProberStatUpdateIntervalCount() const {return mLinkProberStatUpdateIntervalCount;};
+
+    /**
     *@method getSuspendTimeout_msec
     *
     *@brief getter for LinkProber suspend timer timeout
@@ -389,6 +398,7 @@ private:
     uint32_t mTimeoutIpv6_msec = 1000;
     uint32_t mPositiveStateChangeRetryCount = 1;
     uint32_t mNegativeStateChangeRetryCount = 3;
+    uint32_t mLinkProberStatUpdateIntervalCount = 300; 
     uint32_t mSuspendTimeout_msec = 500;
     uint32_t mMuxStateChangeRetryCount = 1;
     uint32_t mLinkStateChangeRetryCount = 1;

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -175,6 +175,15 @@ public:
     inline uint32_t getNegativeStateChangeRetryCount() const {return mMuxConfig.getNegativeStateChangeRetryCount();};
 
     /**
+    *@method getLinkProberStatUpdateIntervalCount
+    *
+    *@brief getter for LinkProber negative state change retry count
+    *
+    *@return state change retry count
+    */
+    inline uint32_t getLinkProberStatUpdateIntervalCount() const {return mMuxConfig.getLinkProberStatUpdateIntervalCount();};
+
+    /**
     *@method getSuspendTimeout_msec
     *
     *@brief getter for LinkProber suspend timer timeout

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -500,7 +500,7 @@ void LinkProber::handleTimeout(boost::system::error_code errorCode)
     mReportHeartbeatReplyNotRecivedFuncPtr();
 
     mIcmpPacketCount++;
-    if (mIcmpPacketCount % mMuxPortConfig.getNegativeStateChangeRetryCount() == 0) {
+    if (mIcmpPacketCount % mMuxPortConfig.getLinkProberStatUpdateIntervalCount() == 0) {
         boost::asio::io_service::strand &strand = mLinkProberStateMachinePtr->getStrand();
         boost::asio::io_service &ioService = strand.context();
         ioService.post(strand.wrap(boost::bind(

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -860,8 +860,8 @@ TEST_F(MuxManagerTest, LinkmgrdConfig)
     EXPECT_TRUE(getTimeoutIpv4_msec(port) == v4PorbeInterval);
     EXPECT_TRUE(getTimeoutIpv6_msec(port) == v6ProveInterval);
     EXPECT_TRUE(getPositiveStateChangeRetryCount(port) == positiveSignalCount);
-    EXPECT_TRUE(getNegativeStateChangeRetryCount(port) == pckLossStatUpdateInterval);
-    EXPECT_TRUE(getLinkProberStatUpdateIntervalCount(port) == negativeSignalCount);
+    EXPECT_TRUE(getNegativeStateChangeRetryCount(port) == negativeSignalCount);
+    EXPECT_TRUE(getLinkProberStatUpdateIntervalCount(port) == pckLossStatUpdateInterval);
     EXPECT_TRUE(getLinkWaitTimeout_msec(port) == (negativeSignalCount + 1) * v4PorbeInterval);
     EXPECT_TRUE(common::MuxLogger::getInstance()->getLevel() == boost::log::trivial::warning);
     EXPECT_TRUE(getIfUseWellKnownMac(port) == useWellKnownMac);
@@ -871,7 +871,6 @@ TEST_F(MuxManagerTest, LinkmgrdConfig)
         {"LINK_PROBER", "SET", {{"interval_pck_loss_count_update", "1"}}},
     };
     processMuxLinkmgrConfigNotifiction(entry);
-
     EXPECT_TRUE(getLinkProberStatUpdateIntervalCount(port) == 50);
 }
 

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -52,6 +52,7 @@ public:
     common::MuxPortConfig::Mode getMode(std::string port);
     uint32_t getPositiveStateChangeRetryCount(std::string port);
     uint32_t getNegativeStateChangeRetryCount(std::string port);
+    uint32_t getLinkProberStatUpdateIntervalCount(std::string port);
     uint32_t getTimeoutIpv4_msec(std::string port);
     uint32_t getTimeoutIpv6_msec(std::string port);
     uint32_t getLinkWaitTimeout_msec(std::string port);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
We are getting `LINK_PROBER_STATS` onboard to stream telemetry, 300ms interval is too much for this message. 

sign-off: Jing Zhang 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->