### PR TITLE
[active-active] Incrementing `BOOST_ASIO_STRAND_IMPLEMENTATIONS`

### DIFF
--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -20,8 +20,6 @@
  *  Created on: Oct 4, 2020
  *      Author: Tamer Ahmed
  */
-// #define BOOST_ASIO_ENABLE_HANDLER_TRACKING 1
-#define BOOST_ASIO_STRAND_IMPLEMENTATIONS 1024
 
 #ifndef MUXMANAGER_H_
 #define MUXMANAGER_H_
@@ -29,6 +27,7 @@
 #include <map>
 #include <memory>
 
+#include <common/BoostAsioBehavior.h>
 #include <boost/asio.hpp>
 #include <boost/asio/signal_set.hpp>
 

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -20,6 +20,8 @@
  *  Created on: Oct 4, 2020
  *      Author: Tamer Ahmed
  */
+// #define BOOST_ASIO_ENABLE_HANDLER_TRACKING 1
+#define BOOST_ASIO_STRAND_IMPLEMENTATIONS 1024
 
 #ifndef MUXMANAGER_H_
 #define MUXMANAGER_H_

--- a/src/common/BoostAsioBehavior.h
+++ b/src/common/BoostAsioBehavior.h
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * MuxConfig.h
+ *
+ *  Created on: Nov 4, 2022
+ *      Author: Jing Zhang
+ */
+
+#ifndef BOOSTASIOBEHAVIOR_H
+#define BOOSTASIOBEHAVIOR_H
+
+// #define BOOST_ASIO_ENABLE_HANDLER_TRACKING 1
+#define BOOST_ASIO_STRAND_IMPLEMENTATIONS 1024
+
+#endif

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -20,6 +20,8 @@
  *  Created on: Oct 9, 2020
  *      Author: Tamer Ahmed
  */
+// #define BOOST_ASIO_ENABLE_HANDLER_TRACKING 1
+#define BOOST_ASIO_STRAND_IMPLEMENTATIONS 1024
 
 #ifndef MUXCONFIG_H_
 #define MUXCONFIG_H_

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -20,8 +20,6 @@
  *  Created on: Oct 9, 2020
  *      Author: Tamer Ahmed
  */
-// #define BOOST_ASIO_ENABLE_HANDLER_TRACKING 1
-#define BOOST_ASIO_STRAND_IMPLEMENTATIONS 1024
 
 #ifndef MUXCONFIG_H_
 #define MUXCONFIG_H_
@@ -29,6 +27,7 @@
 #include <string>
 #include <net/ethernet.h>
 
+#include <common/BoostAsioBehavior.h>
 #include <boost/asio.hpp>
 
 namespace common

--- a/src/common/StateMachine.h
+++ b/src/common/StateMachine.h
@@ -20,6 +20,8 @@
  *  Created on: Oct 4, 2020
  *      Author: Tamer Ahmed
  */
+// #define BOOST_ASIO_ENABLE_HANDLER_TRACKING 1
+#define BOOST_ASIO_STRAND_IMPLEMENTATIONS 1024
 
 #ifndef STATEMACHINE_H_
 #define STATEMACHINE_H_

--- a/src/common/StateMachine.h
+++ b/src/common/StateMachine.h
@@ -20,14 +20,13 @@
  *  Created on: Oct 4, 2020
  *      Author: Tamer Ahmed
  */
-// #define BOOST_ASIO_ENABLE_HANDLER_TRACKING 1
-#define BOOST_ASIO_STRAND_IMPLEMENTATIONS 1024
 
 #ifndef STATEMACHINE_H_
 #define STATEMACHINE_H_
 
 #include <memory>
 
+#include <common/BoostAsioBehavior.h>
 #include <boost/asio.hpp>
 
 #include "common/MuxPortConfig.h"

--- a/src/link_prober/LinkProber.h
+++ b/src/link_prober/LinkProber.h
@@ -21,10 +21,6 @@
  *      Author: tamer
  */
 
-
-// #define BOOST_ASIO_ENABLE_HANDLER_TRACKING 1
-#define BOOST_ASIO_STRAND_IMPLEMENTATIONS 1024
-
 #ifndef LINKPROBER_H_
 #define LINKPROBER_H_
 
@@ -33,6 +29,7 @@
 #include <vector>
 #include <linux/filter.h>
 
+#include <common/BoostAsioBehavior.h>
 #include <boost/asio.hpp>
 #include <boost/function.hpp>
 

--- a/src/link_prober/LinkProber.h
+++ b/src/link_prober/LinkProber.h
@@ -21,6 +21,10 @@
  *      Author: tamer
  */
 
+
+// #define BOOST_ASIO_ENABLE_HANDLER_TRACKING 1
+#define BOOST_ASIO_STRAND_IMPLEMENTATIONS 1024
+
 #ifndef LINKPROBER_H_
 #define LINKPROBER_H_
 

--- a/test/FakeLinkProber.cpp
+++ b/test/FakeLinkProber.cpp
@@ -20,9 +20,8 @@
  *  Created on: Oct 23, 2020
  *      Author: tamer
  */
-// #define BOOST_ASIO_ENABLE_HANDLER_TRACKING 1
-#define BOOST_ASIO_STRAND_IMPLEMENTATIONS 1024
 
+#include <common/BoostAsioBehavior.h>
 #include <boost/asio.hpp>
 #include <boost/bind/bind.hpp>
 

--- a/test/FakeLinkProber.cpp
+++ b/test/FakeLinkProber.cpp
@@ -20,6 +20,8 @@
  *  Created on: Oct 23, 2020
  *      Author: tamer
  */
+// #define BOOST_ASIO_ENABLE_HANDLER_TRACKING 1
+#define BOOST_ASIO_STRAND_IMPLEMENTATIONS 1024
 
 #include <boost/asio.hpp>
 #include <boost/bind/bind.hpp>

--- a/test/FakeMuxPort.h
+++ b/test/FakeMuxPort.h
@@ -20,13 +20,13 @@
  *  Created on: Oct 23, 2020
  *      Author: Tamer Ahmed
  */
-// #define BOOST_ASIO_ENABLE_HANDLER_TRACKING 1
-#define BOOST_ASIO_STRAND_IMPLEMENTATIONS 1024
 
 #ifndef FAKEMUXPORT_H_
 #define FAKEMUXPORT_H_
 
 #include <gtest/gtest.h>
+
+#include <common/BoostAsioBehavior.h>
 #include <boost/asio.hpp>
 
 #include "MuxPort.h"

--- a/test/FakeMuxPort.h
+++ b/test/FakeMuxPort.h
@@ -20,6 +20,8 @@
  *  Created on: Oct 23, 2020
  *      Author: Tamer Ahmed
  */
+// #define BOOST_ASIO_ENABLE_HANDLER_TRACKING 1
+#define BOOST_ASIO_STRAND_IMPLEMENTATIONS 1024
 
 #ifndef FAKEMUXPORT_H_
 #define FAKEMUXPORT_H_


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This is to address to https://github.com/sonic-net/sonic-linkmgrd/issues/153

Needed strand count: 
```
(1 for link prober + 4 for state machines + 1 for mux port) * (# of ports) + 1 for DbInterface + 1 for MuxManager
```
 
sign-off: Jing Zhang zhangjing@microsoft.com 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->