### PR TITLE
fix compile error on arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test-targets: $(OBJS) $(USER_OBJS) $(OBJS_LINKMGRD_TEST)
 	@echo 'Invoking: GCC C++ Linker'
 	$(CXX) -pthread -fprofile-generate -lgcov -o "$(LINKMGRD_TEST_TARGET)" $(OBJS) $(OBJS_LINKMGRD_TEST) $(USER_OBJS) $(LIBS) $(LIBS_TEST)
 	@echo 'Executing test target: $@'
-	LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.5 ./$(LINKMGRD_TEST_TARGET)
+	LD_PRELOAD=/usr/lib/$(shell uname -m)-linux-gnu/libasan.so.5 ./$(LINKMGRD_TEST_TARGET)
 	$(GCOVR) -r ./ --html --html-details -o $(LINKMGRD_TEST_TARGET)-result.html
 	$(GCOVR) -r ./ --xml-pretty -o $(LINKMGRD_TEST_TARGET)-result.xml
 	@echo 'Finished building target: $@'


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
fix compile error on arm64

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
fix compile error on arm64
```
Executing test target: test-targets
LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.5 ./linkmgrd-test
ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libasan.so.5' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.
...
[----------] Global test environment tear-down
[==========] 125 tests from 8 test suites ran. (161324 ms total)
[  PASSED  ] 124 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] LinkManagerStateMachineActiveActiveTest.LinkmgrdBootupSequenceMuxConfigActiveProbeActive

 1 FAILED TEST
make[3]: *** [Makefile:82: test-targets] Error 1
make[3]: Leaving directory '/sonic/src/linkmgrd'
make[2]: *** [Makefile:89: test] Error 2
make[2]: Leaving directory '/sonic/src/linkmgrd'
dh_auto_test: error: make -j6 test returned exit code 2
make[1]: *** [debian/rules:4: build] Error 25
make[1]: Leaving directory '/sonic/src/linkmgrd'
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
```

#### How did you do it?
change x86_64 to uname -m in Makefile

#### How did you verify/test it?
build sonic-linkmgrd_1.0.0-1_arm64.deb

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->