### PR TITLE
[Active-Active] remove chatty messages

### DIFF
--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -272,7 +272,7 @@ void MuxManager::addOrUpdateMuxPortLinkState(const std::string &portName, const 
 //
 void MuxManager::addOrUpdatePeerLinkState(const std::string &portName, const std::string &linkState)
 {
-    MUXLOGWARNING(boost::format("%s: peer link state %s") % portName % linkState);
+    MUXLOGDEBUG(boost::format("%s: peer link state %s") % portName % linkState);
 
     std::shared_ptr<MuxPort> muxPortPtr = getMuxPortPtrOrThrow(portName);
     muxPortPtr->handlePeerLinkState(linkState);

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -260,7 +260,7 @@ void ActiveActiveStateMachine::handleMuxConfigNotification(const common::MuxPort
 //
 void ActiveActiveStateMachine::handleProbeMuxStateNotification(mux_state::MuxState::Label label)
 {
-    MUXLOGWARNING(boost::format("%s: app db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
+    MUXLOGINFO(boost::format("%s: app db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
 
     mWaitTimer.cancel();
     if (label == mux_state::MuxState::Label::Active || label == mux_state::MuxState::Label::Standby) {
@@ -326,7 +326,7 @@ void ActiveActiveStateMachine::handleProbeMuxFailure()
 //
 void ActiveActiveStateMachine::handlePeerMuxStateNotification(mux_state::MuxState::Label label)
 {
-    MUXLOGWARNING(boost::format("%s: app/state db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
+    MUXLOGINFO(boost::format("%s: app/state db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
 
     mPeerWaitTimer.cancel();
     enterPeerMuxState(label);

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -326,7 +326,6 @@ void ActiveActiveStateMachine::handleProbeMuxFailure()
 //
 void ActiveActiveStateMachine::handlePeerMuxStateNotification(mux_state::MuxState::Label label)
 {
-
     MUXLOGDEBUG(boost::format("%s: app/state db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
 
     if (mPeerMuxState != label) {

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -326,7 +326,12 @@ void ActiveActiveStateMachine::handleProbeMuxFailure()
 //
 void ActiveActiveStateMachine::handlePeerMuxStateNotification(mux_state::MuxState::Label label)
 {
-    MUXLOGINFO(boost::format("%s: app/state db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
+
+    MUXLOGDEBUG(boost::format("%s: app/state db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
+
+    if (mPeerMuxState != label) {
+        MUXLOGWARNING(boost::format("%s: server side peer forwarding state : %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
+    }
 
     mPeerWaitTimer.cancel();
     enterPeerMuxState(label);

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -373,6 +373,10 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveLinkProberPeerUnknown)
 
     VALIDATE_PEER_STATE(PeerWait, Wait);
 
+    postPeerLinkProberEvent(link_prober::LinkProberState::PeerActive, 1);
+    handlePeerMuxState("active", 1);
+    VALIDATE_PEER_STATE(PeerActive, Active);
+
     postPeerLinkProberEvent(link_prober::LinkProberState::PeerUnknown, 3);
     VALIDATE_PEER_STATE(PeerUnknown, Standby);
     EXPECT_EQ(mDbInterfacePtr->mSetPeerMuxStateInvokeCount, 1);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This RP is to remove the chatty messages below: 
```
"trimmed_message": ******************** mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:329 handlePeerMuxStateNotification: Ethernet16: app/state db mux state: Unknown,
"count_": 70131
"trimmed_message": ******************** mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:263 handleProbeMuxStateNotification: Ethernet16: app db mux state: Unknown,
"count_": 67479
"trimmed_message": ******************** mux#linkmgrd: MuxManager.cpp:275 addOrUpdatePeerLinkState: Ethernet108: peer link state unknown,
"count_": 6886
```

linkmgrd will still log warning level message if the state changes or triggers a toggle. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Remove unnecessary warning messages. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->