### PR TITLE
[202012] Update link prober stats post logic #159

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -21,6 +21,7 @@
  *      Author: Tamer Ahmed
  */
 
+// GCOVR_EXCL_START
 #include <algorithm>
 #include <tuple>
 
@@ -1150,3 +1151,4 @@ void DbInterface::handleSwssNotification()
 }
 
 } /* namespace common */
+// GCOVR_EXCL_STOP

--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -447,9 +447,8 @@ void DbInterface::handlePostLinkProberMetrics(
         mLinkProbeMetrics[static_cast<int> (metrics)]
     );
 
-    if (metrics == link_manager::LinkManagerStateMachine::LinkProberMetrics::LinkProberUnknownStart) {
-        mStateDbLinkProbeStatsTablePtr->hdel(portName, mLinkProbeMetrics[0]);
-        mStateDbLinkProbeStatsTablePtr->hdel(portName, mLinkProbeMetrics[1]);
+    for (auto linkProberMetricsEvent:mLinkProbeMetrics) {
+        mStateDbLinkProbeStatsTablePtr->hdel(portName, linkProberMetricsEvent);
     }
 
     mStateDbLinkProbeStatsTablePtr->hset(portName, mLinkProbeMetrics[static_cast<int> (metrics)], boost::posix_time::to_simple_string(time));
@@ -475,8 +474,11 @@ void DbInterface::handlePostPckLossRatio(
         expectedPacketCount
     );
 
-    mStateDbLinkProbeStatsTablePtr->hset(portName, "pck_loss_count", std::to_string(unknownEventCount));
-    mStateDbLinkProbeStatsTablePtr->hset(portName, "pck_expected_count", std::to_string(expectedPacketCount));
+
+    std::vector<swss::FieldValueTuple> fieldValues;
+    fieldValues.push_back(std::make_pair("pck_loss_count", std::to_string(unknownEventCount)));
+    fieldValues.push_back(std::make_pair("pck_expected_count", std::to_string(expectedPacketCount)));
+    mStateDbLinkProbeStatsTablePtr->set(portName, fieldValues);
 }
 
 //

--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -507,7 +507,6 @@ void LinkManagerStateMachine::handleStateChange(LinkProberEvent &event, link_pro
         // update state db link prober metrics to collect link prober state change data
         if (mContinuousLinkProberUnknownEvent == true && state != link_prober::LinkProberState::Unknown) {
             mContinuousLinkProberUnknownEvent = false;
-            mMuxPortPtr->postLinkProberMetricsEvent(link_manager::LinkManagerStateMachine::LinkProberMetrics::LinkProberUnknownEnd);
         } 
         
         if (mContinuousLinkProberUnknownEvent == false && state == link_prober::LinkProberState::Label::Unknown) {

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1192,7 +1192,7 @@ TEST_F(LinkManagerStateMachineTest, PostPckLossMetricsEvent)
     EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 3); // post link_prober_unknown_start, link_prober_wait_start
     postLinkProberEvent(link_prober::LinkProberState::Active, 3);
     
-    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 5); // post link_prober_unknown_start, post link_prober_active_start
+    EXPECT_EQ(mDbInterfacePtr->mPostLinkProberMetricsInvokeCount, 4); // post link_prober_unknown_start, post link_prober_active_start
 }
 
 TEST_F(LinkManagerStateMachineTest, PostPckLossUpdateAndResetEvent)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to address the agreement with Streaming Telemetry team on onboarding link prober packet loss data:
1. keep only state transition event in the table (each message)
2. batch update counters to avoid separate messages, i.e. `pck_expected_count` and `pck_loss_count` should be update in one transaction. 

sign-off: Jing Zhang zhangjing@microsoft.com 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To simplify message processing on Streaming Telemetry side. 

#### How did you do it?

#### How did you verify/test it?
Stop icmp_responder:
```
admin@svcstr-7050-acs-1:~$ show mux packetloss Ethernet4
PORT       COUNT                 VALUE
---------  ------------------  -------
Ethernet4  pck_expected_count     1600
Ethernet4  pck_loss_count          367
PORT       EVENT                      TIME
---------  -------------------------  ---------------------------
Ethernet4  link_prober_unknown_start  2022-Dec-05 21:12:16.541374
```
Re-start icmp_responder:
```
admin@svcstr-7050-acs-1:~$ show mux packetloss Ethernet4
PORT       COUNT                 VALUE
---------  ------------------  -------
Ethernet4  pck_expected_count     1700
Ethernet4  pck_loss_count          399
PORT       EVENT                     TIME
---------  ------------------------  ---------------------------
Ethernet4  link_prober_active_start  2022-Dec-05 21:12:45.548291
```


#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->