### PR TITLE
[active-active] update linkmgr health label definition

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -186,6 +186,7 @@ void ActiveActiveStateMachine::handleMuxStateNotification(mux_state::MuxState::L
         mResumeTxFnPtr();
         postMuxStateEvent(label);
         mMuxPortPtr->postMetricsEvent(Metrics::SwitchingEnd, label);
+        updateMuxLinkmgrState();
     } else {
         if (label == mux_state::MuxState::Unknown) {
             MUXLOGWARNING(

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -996,7 +996,7 @@ void ActiveActiveStateMachine::updateMuxLinkmgrState()
     Label label = Label::Unhealthy;
     if (ls(mCompositeState) == link_state::LinkState::Label::Up &&
         ps(mCompositeState) == link_prober::LinkProberState::Label::Active &&
-        ms(mCompositeState) != mux_state::MuxState::Label::Standby &&
+        (ms(mCompositeState) == mLastMuxStateNotification || mLastMuxStateNotification == mux_state::MuxState::Label::Unknown) &&
         (mMuxPortConfig.ifEnableDefaultRouteFeature() == false || mDefaultRouteState == DefaultRoute::OK)) {
         label = Label::Healthy;
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to update the definition of `unhealthy` label for active-active interfaces, to be considered as "healthy":
* Link status must be up 
* Heartbeat response mux be received
* Server status should be in sync with ToR side status, **OR** server is unable to respond its status. 

sign-off: Jing Zhang zhngjing@microsoft.com 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
* Config interface to `standby` 
```
admin@**************:~$ show mux status Ethernet44
PORT        STATUS    SERVER_STATUS    HEALTH    HWSTATUS    LAST_SWITCHOVER_TIME
----------  --------  ---------------  --------  ----------  ---------------------------
Ethernet44  standby   standby          healthy   consistent  2023-Jan-25 01:11:13.228902
```

* Config interface to `auto` 
```
admin@**************:~$ show mux status Ethernet44
PORT        STATUS    SERVER_STATUS    HEALTH    HWSTATUS    LAST_SWITCHOVER_TIME
----------  --------  ---------------  --------  ----------  ---------------------------
Ethernet44  active    active           healthy   consistent  2023-Jan-25 01:14:26.909006
```

* Server status unknown
```
admin@**************:~$ show mux status Ethernet44
PORT        STATUS    SERVER_STATUS    HEALTH    HWSTATUS    LAST_SWITCHOVER_TIME
----------  --------  ---------------  --------  ----------  ---------------------------
Ethernet44  active    unknown          healthy   consistent  2023-Jan-25 01:14:26.909006

admin@**************:~$ show mux status Ethernet44
PORT        STATUS    SERVER_STATUS    HEALTH    HWSTATUS    LAST_SWITCHOVER_TIME
----------  --------  ---------------  --------  ----------  ---------------------------
Ethernet44  standby   unknown          healthy   consistent  2023-Jan-25 01:15:03.012912
```

* Status mismatch 
```
admin@**************:~$ show mux status Ethernet44
PORT        STATUS    SERVER_STATUS    HEALTH     HWSTATUS    LAST_SWITCHOVER_TIME
----------  --------  ---------------  ---------  ----------  ---------------------------
Ethernet44  active    standby          unhealthy  consistent  2023-Jan-25 01:12:25.175324
```

* shutdown interface 
```
admin@**************:~$ sudo config interface shutdown Ethernet44
admin@**************:~$ show mux status Ethernet44
PORT        STATUS    SERVER_STATUS    HEALTH     HWSTATUS      LAST_SWITCHOVER_TIME
----------  --------  ---------------  ---------  ------------  ----------------------
Ethernet44  standby   unknown          unhealthy  inconsistent
```

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->