### PR TITLE
[active-active] force switch when config == active && target state == active

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -935,8 +935,7 @@ void ActiveActiveStateMachine::switchMuxState(
     if (forceSwitch ||
         mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto ||
         mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Detached ||
-        (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Active && label == mux_state::MuxState::Label::Active)
-        ) {
+        (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Active && label == mux_state::MuxState::Label::Active)) {
         MUXLOGWARNING(
             boost::format("%s: Switching MUX state to '%s'") %
             mMuxPortConfig.getPortName() %

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -934,7 +934,9 @@ void ActiveActiveStateMachine::switchMuxState(
 {
     if (forceSwitch ||
         mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto ||
-        mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Detached) {
+        mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Detached ||
+        (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Active && label == mux_state::MuxState::Label::Active)
+        ) {
         MUXLOGWARNING(
             boost::format("%s: Switching MUX state to '%s'") %
             mMuxPortConfig.getPortName() %


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Noticed the edge case below in dev cluster today:
1. mux mode was configured to `active` and wasn't configured back to `auto`
2. gRPC server restarted with server side forwarding state changed to `standby`
3. no re-sync happened;

```
Jan 28 01:58:49.236160 ************** NOTICE pmon#ycable[13485]: calling RPC for getting forwarding state port = Ethernet4 portid 0 peer portid 1 read_side 0
Jan 28 01:58:49.737700 ************** NOTICE pmon#ycable[13485]: response was none handle_fwd_state_command_grpc_notification Ethernet4 
Jan 28 01:58:53.564397 ************** WARNING mux#linkmgrd: message repeated 2 times: [ link_manager/LinkManagerStateMachineActiveActive.cpp:1136 handleMuxWaitTimeout: Ethernet4: xcvrd timed out responding to linkmgrd, current state: (P: Active, M: Unknown, L: Up)]
Jan 28 01:58:54.327870 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:1136 handleMuxWaitTimeout: Ethernet4: xcvrd timed out responding to linkmgrd, current state: (P: Active, M: Unknown, L: Up)
Jan 28 01:58:54.444840 ************** NOTICE pmon#ycable[13485]: calling RPC for getting forwarding state port = Ethernet4 portid 0 peer portid 1 read_side 0
Jan 28 01:58:54.447695 ************** NOTICE pmon#ycable[13485]: forwarding state RPC received response port = Ethernet4 portids [0, 1] read_side 0
Jan 28 01:58:54.447744 ************** NOTICE pmon#ycable[13485]: forwarding state RPC received response port = Ethernet4 state values = [False, True] read_side 0
Jan 28 01:58:54.448746 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:332 handlePeerMuxStateNotification: Ethernet4: server side peer forwarding state : Active
Jan 28 01:58:54.448802 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:516 handleStateChange: Ethernet4: Received mux state event, new state: Standby
Jan 28 01:58:54.449320 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:845 setLabel: Ethernet4: Linkmgrd state is: Standby Unhealthy
Jan 28 01:58:54.450055 ************** NOTICE pmon#ycable[13485]: calling RPC for getting forwarding state port = Ethernet4 portid 0 peer portid 1 read_side 0
Jan 28 01:58:54.452271 ************** NOTICE pmon#ycable[13485]: forwarding state RPC received response port = Ethernet4 portids [0, 1] read_side 0
Jan 28 01:58:54.452316 ************** NOTICE pmon#ycable[13485]: forwarding state RPC received response port = Ethernet4 state values = [False, True] read_side 0
Jan 28 01:58:54.454061 ************** NOTICE pmon#ycable[13485]: calling RPC for getting forwarding state port = Ethernet4 portid 0 peer portid 1 read_side 0
Jan 28 01:58:54.459025 ************** NOTICE pmon#ycable[13485]: forwarding state RPC received response port = Ethernet4 portids [0, 1] read_side 0
Jan 28 01:58:54.459084 ************** NOTICE pmon#ycable[13485]: forwarding state RPC received response port = Ethernet4 state values = [False, True] read_side 0

```

The reason was this switchover was not "forced" and then was skipped due to non-auto mode. 

https://github.com/sonic-net/sonic-linkmgrd/blob/9bdcf9b03e9e33ec9ff4cb6148fc57b4f610a7a4/src/link_manager/LinkManagerStateMachineActiveActive.cpp#L731-L735

This PR is to force switch if both target state and config are `active`. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->