### PR TITLE
Fix mux config when gRPC connection is lost

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -241,6 +241,8 @@ void ActiveActiveStateMachine::handleMuxConfigNotification(const common::MuxPort
         CompositeState nextState = mCompositeState;
         if (mode == common::MuxPortConfig::Mode::Active && ms(mCompositeState) != mux_state::MuxState::Label::Active) {
             switchMuxState(nextState, mux_state::MuxState::Label::Active, true);
+        } else if (mode == common::MuxPortConfig::Mode::Auto && ms(mCompositeState) == mux_state::MuxState::Label::Unknown) {
+            initLinkProberState(nextState);
         } else if (mode == common::MuxPortConfig::Mode::Standby && ms(mCompositeState) != mux_state::MuxState::Label::Standby) {
             switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
         } else {

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -241,10 +241,11 @@ void ActiveActiveStateMachine::handleMuxConfigNotification(const common::MuxPort
         CompositeState nextState = mCompositeState;
         if (mode == common::MuxPortConfig::Mode::Active && ms(mCompositeState) != mux_state::MuxState::Label::Active) {
             switchMuxState(nextState, mux_state::MuxState::Label::Active, true);
-        } else if (mode == common::MuxPortConfig::Mode::Auto && ms(mCompositeState) == mux_state::MuxState::Label::Unknown) {
-            initLinkProberState(nextState);
         } else if (mode == common::MuxPortConfig::Mode::Standby && ms(mCompositeState) != mux_state::MuxState::Label::Standby) {
             switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
+        } else if (mode == common::MuxPortConfig::Mode::Auto && ms(mCompositeState) == mux_state::MuxState::Label::Unknown) {
+            MUXLOGINFO(boost::format("%s: reset link prober state") % mMuxPortConfig.getPortName());
+            initLinkProberState(nextState);
         } else {
             // enforce a state transtion calculation based on current states
             mStateTransitionHandler[ps(nextState)][ms(nextState)][ls(nextState)](nextState);

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -792,4 +792,64 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActivePeriodicalCheck)
     VALIDATE_STATE(Active, Active, Up);
 }
 
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveConfigStandbygRPCError)
+{
+    setMuxActive();
+
+    handleMuxConfig("standby", 1);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+    VALIDATE_STATE(Active, Standby, Up);
+
+    handleMuxState("unknown", 3);
+    VALIDATE_STATE(Active, Unknown, Up);
+
+    handleProbeMuxState("unknown", 4);
+    VALIDATE_STATE(Active, Unknown, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Active, 3);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    VALIDATE_STATE(Active, Unknown, Up);
+
+    handleMuxConfig("auto", 1);
+    VALIDATE_STATE(Wait, Unknown, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Active, 3);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
+    VALIDATE_STATE(Active, Active, Up);
+
+    handleMuxState("unknown", 4);
+    VALIDATE_STATE(Active, Unknown, Up);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxStandbyConfigStandbygRPCError)
+{
+    setMuxStandby();
+
+    handleMuxConfig("active", 1);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+    VALIDATE_STATE(Unknown, Active, Up);
+
+    handleMuxState("unknown", 3);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+
+    handleProbeMuxState("unknown", 4);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 3);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+
+    handleMuxConfig("auto", 1);
+    VALIDATE_STATE(Wait, Unknown, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 3);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
+    VALIDATE_STATE(Unknown, Standby, Up);
+
+    handleMuxState("unknown", 4);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+}
+
 } /* namespace test */


### PR DESCRIPTION

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #165

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Fix issue: https://github.com/sonic-net/sonic-linkmgrd/issues/165

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Reset the link prober state if the mux state is unknown when the mux config is changed back from `active` or `standby` to `auto`.

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->