### PR TITLE
[active-active] fix issue that interfaces get stuck in `active` if service starts up with link state down

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -852,7 +852,7 @@ void ActiveActiveStateMachine::LinkProberUnknownMuxWaitLinkUpTransitionFunction(
 //
 // ---> LinkProberUnknownMuxWaitLinkDownTransitionFunction(CompositeState &nextState)
 //
-// transition function when entering {LinkProberUnnown, MuxWait, LinkDown} state
+// transition function when entering {LinkProberUnknown, MuxWait, LinkDown} state
 //
 void ActiveActiveStateMachine::LinkProberUnknownMuxWaitLinkDownTransitionFunction(CompositeState &nextState)
 {
@@ -867,7 +867,7 @@ void ActiveActiveStateMachine::LinkProberUnknownMuxWaitLinkDownTransitionFunctio
 //
 // ---> LinkProberUnknownMuxUnknownLinkDownTransitionFunction(CompositeState &nextState)
 //
-// transition function when entering {LinkProberUnnown, MuxUnknown, LinkDown} state
+// transition function when entering {LinkProberUnknown, MuxUnknown, LinkDown} state
 //
 void ActiveActiveStateMachine::LinkProberUnknownMuxUnknownLinkDownTransitionFunction(CompositeState &nextState)
 {

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -706,6 +706,24 @@ void ActiveActiveStateMachine::initializeTransitionFunctionTable()
                                    this,
                                    boost::placeholders::_1
                                );
+
+    mStateTransitionHandler[link_prober::LinkProberState::Label::Unknown]
+                           [mux_state::MuxState::Label::Wait]
+                           [link_state::LinkState::Label::Down] =
+                               boost::bind(
+                                   &ActiveActiveStateMachine::LinkProberUnknownMuxWaitLinkDownTransitionFunction,
+                                   this,
+                                   boost::placeholders::_1
+                               );
+
+    mStateTransitionHandler[link_prober::LinkProberState::Label::Unknown]
+                           [mux_state::MuxState::Label::Unknown]
+                           [link_state::LinkState::Label::Down] =
+                               boost::bind(
+                                   &ActiveActiveStateMachine::LinkProberUnknownMuxUnknownLinkDownTransitionFunction,
+                                   this,
+                                   boost::placeholders::_1
+                               );
 }
 
 //
@@ -829,6 +847,36 @@ void ActiveActiveStateMachine::LinkProberUnknownMuxWaitLinkUpTransitionFunction(
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
     switchMuxState(nextState, mux_state::MuxState::Label::Standby);
+}
+
+//
+// ---> LinkProberUnknownMuxWaitLinkDownTransitionFunction(CompositeState &nextState)
+//
+// transition function when entering {LinkProberUnnown, MuxWait, LinkDown} state
+//
+void ActiveActiveStateMachine::LinkProberUnknownMuxWaitLinkDownTransitionFunction(CompositeState &nextState)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+    if (ps(mCompositeState) != link_prober::LinkProberState::Unknown) {
+        switchMuxState(nextState, mux_state::MuxState::Label::Standby);
+    } else {
+        startMuxProbeTimer();
+    }
+}
+
+//
+// ---> LinkProberUnknownMuxUnknownLinkDownTransitionFunction(CompositeState &nextState)
+//
+// transition function when entering {LinkProberUnnown, MuxUnknown, LinkDown} state
+//
+void ActiveActiveStateMachine::LinkProberUnknownMuxUnknownLinkDownTransitionFunction(CompositeState &nextState)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+    if (ps(mCompositeState) != link_prober::LinkProberState::Unknown) {
+        switchMuxState(nextState, mux_state::MuxState::Label::Standby);
+    } else {
+        startMuxProbeTimer();
+    }
 }
 
 /*--------------------------------------------------------------------------------------------------------------

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -359,7 +359,7 @@ public: // state transition functions
     /**
      * @method LinkProberUnknownMuxWaitLinkDownTransitionFunction
      * 
-     * @brief transition function when entering {LinkProberUnnown, MuxWait, LinkDown} state
+     * @brief transition function when entering {LinkProberUnknown, MuxWait, LinkDown} state
      * 
      * @param nextState                     reference to composite state
      */
@@ -368,7 +368,7 @@ public: // state transition functions
     /**
      * @method LinkProberUnknownMuxUnknownLinkDownTransitionFunction
      * 
-     * @brief transition function when entering {LinkProberUnnown, MuxUnknown, LinkDown} state
+     * @brief transition function when entering {LinkProberUnknown, MuxUnknown, LinkDown} state
      * 
      * @param nextState                     reference to composite state
      */

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -356,6 +356,24 @@ public: // state transition functions
      */
     void LinkProberUnknownMuxWaitLinkUpTransitionFunction(CompositeState &nextState);
 
+    /**
+     * @method LinkProberUnknownMuxWaitLinkDownTransitionFunction
+     * 
+     * @brief transition function when entering {LinkProberUnnown, MuxWait, LinkDown} state
+     * 
+     * @param nextState                     reference to composite state
+     */
+    void LinkProberUnknownMuxWaitLinkDownTransitionFunction(CompositeState &nextState);
+
+    /**
+     * @method LinkProberUnknownMuxUnknownLinkDownTransitionFunction
+     * 
+     * @brief transition function when entering {LinkProberUnnown, MuxUnknown, LinkDown} state
+     * 
+     * @param nextState                     reference to composite state
+     */
+    void LinkProberUnknownMuxUnknownLinkDownTransitionFunction(CompositeState &nextState);
+
 private: // utility methods to check/modify state
     /**
      * @method setLabel

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -852,7 +852,7 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxStandbyConfigStandbygRPCError
     VALIDATE_STATE(Unknown, Unknown, Up);
 }
 
-TEST_F(LinkManagerStateMachineActiveActiveTest, StateMachineActivatedLinkDown)
+TEST_F(LinkManagerStateMachineActiveActiveTest, StateMachineActivatedLinkDownLinkProberFirst)
 {
     activateStateMachine();
     VALIDATE_STATE(Wait, Wait, Down);
@@ -866,7 +866,25 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, StateMachineActivatedLinkDown)
     handleMuxState("unknown", 3);
     VALIDATE_STATE(Unknown, Unknown, Down);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+}
 
+TEST_F(LinkManagerStateMachineActiveActiveTest, StateMachineActivatedLinkDownMuxFirst)
+{
+    activateStateMachine();
+    VALIDATE_STATE(Wait, Wait, Down);
+
+    handleMuxState("unknown", 3);
+    VALIDATE_STATE(Wait, Unknown, Down);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 2);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+    VALIDATE_STATE(Unknown, Standby, Down);
+
+    handleMuxState("unknown", 3);
+    VALIDATE_STATE(Unknown, Unknown, Down);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
 }
 
 } /* namespace test */

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -852,4 +852,21 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxStandbyConfigStandbygRPCError
     VALIDATE_STATE(Unknown, Unknown, Up);
 }
 
+TEST_F(LinkManagerStateMachineActiveActiveTest, StateMachineActivatedLinkDown)
+{
+    activateStateMachine();
+    VALIDATE_STATE(Wait, Wait, Down);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 2);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+    VALIDATE_STATE(Unknown, Standby, Down);
+
+    handleMuxState("unknown", 3);
+    VALIDATE_STATE(Unknown, Unknown, Down);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+
+}
+
 } /* namespace test */


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

To fix issue #168. 

In the failure scenario, the event sequence was 
- write_standby set state to "active" when services restarted
- mux config `auto`
- init link state `down`
- init mux state `unknown`
- state machine activated, re-init link prober state to (wait, wait, down)
- link prober state event: unknown, supposed to switch to `standby`, but there wasn't transaction handler defined for "unknown, unknown, down" or  "unknown, wait, down"

The fix here is to define no-op handlers to enforce a `standby` state or a state probing. 

sign-off: Jing Zhang zhangjing@microsoft.com. 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To switch `active` interface into `standby` if link state is down after booting up. 

#### How did you do it?
Define link down related state transition handlers. 

#### How did you verify/test it?
Tested on active-active dualtor, `show mux status` return `standby` eventually after service was restarted.

```
Feb 13 20:22:17.171796 ************** WARNING mux#linkmgrd: MuxManager.cpp:207 updateMuxPortConfig: Ethernet48: Mux port config: auto
Feb 13 20:22:17.181742 ************** WARNING mux#linkmgrd: MuxManager.cpp:262 addOrUpdateMuxPortLinkState: Ethernet48: link state: down
Feb 13 20:22:17.182122 ************** INFO mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:217 handleSwssLinkStateNotification: Ethernet48: state db link state: Down
Feb 13 20:22:17.186123 ************** INFO mux#linkmgrd: MuxManager.cpp:353 processProbeMuxState: Ethernet48: app db mux state: failure
Feb 13 20:22:17.186989 ************** WARNING mux#linkmgrd: MuxManager.cpp:288 addOrUpdateMuxPortMuxState: Ethernet48: state db mux state: unknown
Feb 13 20:22:17.188745 ************** WARNING mux#linkmgrd: MuxPort.cpp:365 handleDefaultRouteState: port: Ethernet48, state db default route state: ok
Feb 13 20:22:17.311179 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:176 handleMuxStateNotification: Ethernet48: state db mux state: Unknown
Feb 13 20:22:17.311265 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:192 handleMuxStateNotification: Ethernet48: ycabled reports MUX state as 'Unknown' during init. phase! Is there a functioning gRPC server?
Feb 13 20:22:17.311303 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:86 activateStateMachine: Ethernet48: (P: Wait, M: Wait, L: Down) -> (P: Wait, M: Wait, L: Down)
Feb 13 20:22:17.334812 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:894 setLabel: Ethernet48: Linkmgrd state is: Wait Unhealthy
Feb 13 20:22:17.840997 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:517 handleStateChange: Ethernet48: Received mux state event, new state: Unknown
Feb 13 20:22:17.841437 ************** INFO mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:526 handleStateChange: Ethernet48: (P: Wait, M: Wait, L: Down) -> (P: Wait, M: Unknown, L: Down)
Feb 13 20:22:20.335101 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:479 handleStateChange: Ethernet48: Received link prober event, new state: Unknown
Feb 13 20:22:20.335256 ************** INFO mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:871 LinkProberUnknownMuxUnknownLinkDownTransitionFunction: Ethernet48
Feb 13 20:22:20.335398 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:987 switchMuxState: Ethernet48: Switching MUX state to 'Standby'
Feb 13 20:22:20.335451 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:499 handleStateChange: Ethernet48: (P: Wait, M: Unknown, L: Down) -> (P: Unknown, M: Standby, L: Down)
Feb 13 20:22:20.886410 ************** WARNING mux#linkmgrd: MuxManager.cpp:288 addOrUpdateMuxPortMuxState: Ethernet48: state db mux state: unknown
Feb 13 20:22:20.886761 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:176 handleMuxStateNotification: Ethernet48: state db mux state: Unknown
Feb 13 20:22:20.887113 ************** WARNING mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:517 handleStateChange: Ethernet48: Received mux state event, new state: Unknown
Feb 13 20:22:20.887294 ************** INFO mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:871 LinkProberUnknownMuxUnknownLinkDownTransitionFunction: Ethernet48
Feb 13 20:22:20.887455 ************** INFO mux#linkmgrd: link_manager/LinkManagerStateMachineActiveActive.cpp:526 handleStateChange: Ethernet48: (P: Unknown, M: Standby, L: Down) -> (P: Unknown, M: Unknown, L: Down)
```

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->