### PR TITLE
[active-active] Toggle to standby if default route is missing

### DIFF
--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -461,10 +461,34 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActivDefaultRouteState)
     postDefaultRouteEvent("na", 1);
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount, 1);
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+    VALIDATE_STATE(Active, Standby, Up);
 
     postDefaultRouteEvent("ok", 1);
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount, 1);
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount, 3);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActivDefaultRouteStateMuxConfigActive)
+{
+    setMuxActive();
+    VALIDATE_STATE(Active, Active, Up);
+    EXPECT_FALSE(mMuxConfig.getIfEnableDefaultRouteFeature());
+
+    mMuxConfig.enableDefaultRouteFeature(true);
+    postDefaultRouteEvent("ok", 1);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount, 0);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount, 1);
+
+    handleMuxConfig("active", 2);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount, 2);
+
+    postDefaultRouteEvent("na", 1);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount, 0);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount, 3);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    VALIDATE_STATE(Active, Active, Up);
 }
 
 TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceHeartBeatFirst)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To avoid extra disruption after a BGP shutdown.
The reason is that, after a BGP shutdown, `linkmgrd` will stop heartbeats, and both local ToR and peer ToR will receive the heartbeat missing and toggle the local ToR to standby.
There is a chance that the peer ToR toggles local ToR to standby first, and the local ToR will probe the mux finding that itself mux state as `standby`, the local ToR will toggle itself back to active. When the local ToR receives the link prober unknown event, it will toggle itself into `standby` at last.

The event sequence:

![bgp_down_before](https://user-images.githubusercontent.com/35479537/219675561-ea217335-c339-44a9-80ba-81e40def393f.jpg)



Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
When `linkmgrd` receives default route missing event, make an extra toggle to `standby`, so local ToR's toggle to standby should be earlier than peer ToR's.
And the disruption total time could be reduced because `linkmgrd` makes the toggle immediately after receiving the default  route missing event instead of waiting for the link prober unknown event after shutdown the heartbeat sending.

The event sequence after:

![bgp_down_after](https://user-images.githubusercontent.com/35479537/219675638-20fba601-22ad-4bb1-a83f-0da5493746d3.jpg)


#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->