### PR TITLE
[active-standby] Toggle to standby if link down and config auto

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -770,8 +770,17 @@ void ActiveStandbyStateMachine::handleMuxConfigNotification(const common::MuxPor
             mSendSwitchActiveCommandCause = link_manager::ActiveStandbyStateMachine::SwitchCause::ConfigMuxMode;
             mSendPeerSwitchCommandFnPtr();
         } else {
-            mMuxStateMachine.setWaitStateCause(mux_state::WaitState::WaitStateCause::DriverUpdate);
-            mMuxPortPtr->probeMuxState();
+            LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, mCompositeState);
+            if (ls(mCompositeState) == link_state::LinkState::Down &&
+                ms(mCompositeState) != mux_state::MuxState::Label::Standby) {
+                CompositeState nextState = mCompositeState;
+                switchMuxState(link_manager::ActiveStandbyStateMachine::SwitchCause::LinkDown, nextState, mux_state::MuxState::Label::Standby, true);
+                LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
+                mCompositeState = nextState;
+            } else {
+                mMuxStateMachine.setWaitStateCause(mux_state::WaitState::WaitStateCause::DriverUpdate);
+                mMuxPortPtr->probeMuxState();
+            }
         }
 
         updateMuxLinkmgrState();

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -564,6 +564,39 @@ TEST_F(LinkManagerStateMachineTest, MuxStandbyLinkDown)
     VALIDATE_STATE(Standby, Standby, Up);
 }
 
+TEST_F(LinkManagerStateMachineTest, MuxStandbyLinkDownMuxStandbyCliActiveCliAuto)
+{
+    setMuxStandby();
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
+
+    handleLinkState("down", 3);
+    VALIDATE_STATE(Standby, Standby, Down);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 2);
+    VALIDATE_STATE(Unknown, Standby, Down);
+
+    runIoService(1);
+    VALIDATE_STATE(Unknown, Wait, Down);
+
+    handleProbeMuxState("standby", 3);
+    VALIDATE_STATE(Unknown, Standby, Down);
+
+    handleMuxConfig("active", 2);
+    VALIDATE_STATE(Wait, Wait, Down);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+
+    handleMuxState("active", 3);
+    VALIDATE_STATE(Wait, Active, Down);
+
+    handleMuxConfig("auto", 2);
+    VALIDATE_STATE(Wait, Wait, Down);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+
+    handleMuxState("standby", 3);
+    VALIDATE_STATE(Wait, Standby, Down);
+}
+
 TEST_F(LinkManagerStateMachineTest, MuxActiveLinkProberUnknownPeerOvertakeLink)
 {
     setMuxActive();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #172

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Fix the issue that in the link down scenario, if config active then back auto, the mux state could be changed into standby.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
Make an extra toggle in this case.

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->