### PR TITLE
[active-active] link operational down didn't trigger toggle to standby if `MuxUnknown` event arrives first. 

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -555,7 +555,7 @@ void ActiveActiveStateMachine::handleStateChange(
         if (ls(mCompositeState) == link_state::LinkState::Down && ls(nextState) == link_state::LinkState::Up) {
             initLinkProberState(nextState);
             initPeerLinkProberState();
-        } else if (ls(mCompositeState) == link_state::LinkState::Up && ls(nextState) == link_state::LinkState::Down && ms(mCompositeState) == mux_state::MuxState::Label::Active) {
+        } else if (ls(mCompositeState) == link_state::LinkState::Up && ls(nextState) == link_state::LinkState::Down && ms(mCompositeState) != mux_state::MuxState::Label::Standby) {
             switchMuxState(nextState, mux_state::MuxState::Label::Standby);
         } else {
             mStateTransitionHandler[ps(nextState)][ms(nextState)][ls(nextState)](nextState);

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -328,6 +328,25 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveLinkDown)
     VALIDATE_STATE(Active, Active, Up);
 }
 
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveLinkDownMuxUnknownFirsrt)
+{
+    setMuxActive();
+
+    handleProbeMuxState("unknown", 4);
+    VALIDATE_STATE(Active, Unknown, Up);
+
+    postLinkEvent(link_state::LinkState::Label::Down, 3);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+    VALIDATE_STATE(Active, Standby, Down);
+
+    handleMuxState("unknown", 4);
+    VALIDATE_STATE(Active, Unknown, Down);
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 4);
+    VALIDATE_STATE(Unknown, Unknown, Down);
+}
+
 TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveConfigStandby)
 {
     setMuxActive();

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -340,10 +340,10 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveLinkDownMuxUnknownFirsr
     EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
     VALIDATE_STATE(Active, Standby, Down);
 
-    handleMuxState("unknown", 4);
-    VALIDATE_STATE(Active, Unknown, Down);
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 3);
+    VALIDATE_STATE(Unknown, Standby, Down);
 
-    postLinkProberEvent(link_prober::LinkProberState::Unknown, 4);
+    handleMuxState("unknown", 3);
     VALIDATE_STATE(Unknown, Unknown, Down);
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fix #174. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?
Unit tests. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->