### PR TITLE
[active-standby] update the check before toggling standby for link down 

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -547,7 +547,7 @@ void ActiveStandbyStateMachine::handleStateChange(LinkStateEvent &event, link_st
 //            enterMuxWaitState(nextState);
         } else if (ls(mCompositeState) == link_state::LinkState::Up &&
                    ls(nextState) == link_state::LinkState::Down &&
-                   ms(mCompositeState) == mux_state::MuxState::Label::Active) {
+                   ms(mCompositeState) != mux_state::MuxState::Label::Standby) {
             // switch MUX to standby since we are entering LinkDown state
             switchMuxState(link_manager::ActiveStandbyStateMachine::SwitchCause::LinkDown, nextState, mux_state::MuxState::Label::Standby);
         } else {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This is to fix the edge case when link down event comes after mux probing/toggling failure. 

The switchover still needs to happen to keep orchagent state up-to-date. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
This edge case causes both side active and traffic drop.

#### How did you do it?

#### How did you verify/test it?
UTs. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->