### PR TITLE
[active-active] add state transition handler for (LinkProber: Unknown, MuxState: Active, LinkState: Down)

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -724,6 +724,15 @@ void ActiveActiveStateMachine::initializeTransitionFunctionTable()
                                    this,
                                    boost::placeholders::_1
                                );
+
+    mStateTransitionHandler[link_prober::LinkProberState::Label::Unknown]
+                           [mux_state::MuxState::Label::Active]
+                           [link_state::LinkState::Label::Down] =
+                               boost::bind(
+                                   &ActiveActiveStateMachine::LinkProberUnknownMuxActiveLinkDownTransitionFunction,
+                                   this,
+                                   boost::placeholders::_1
+                               );
 }
 
 //
@@ -877,6 +886,17 @@ void ActiveActiveStateMachine::LinkProberUnknownMuxUnknownLinkDownTransitionFunc
     } else {
         startMuxProbeTimer();
     }
+}
+
+//
+// ---> LinkProberUnknownMuxActiveLinkDownTransitionFunction(CompositeState &nextState)
+//
+// transition function when entering {LinkProberUnknown, MuxUnknown, LinkDown} state
+//
+void ActiveActiveStateMachine::LinkProberUnknownMuxActiveLinkDownTransitionFunction(CompositeState &nextState)
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+    switchMuxState(nextState, mux_state::MuxState::Label::Standby);
 }
 
 /*--------------------------------------------------------------------------------------------------------------

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -374,6 +374,15 @@ public: // state transition functions
      */
     void LinkProberUnknownMuxUnknownLinkDownTransitionFunction(CompositeState &nextState);
 
+    /**
+     * @method LinkProberUnknownMuxActiveLinkDownTransitionFunction
+     * 
+     * @brief transition function when entering {LinkProberUnknown, MuxUnknown, LinkDown} state
+     * 
+     * @param nextState                     reference to composite state
+     */
+    void LinkProberUnknownMuxActiveLinkDownTransitionFunction(CompositeState &nextState);
+
 private: // utility methods to check/modify state
     /**
      * @method setLabel

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -930,4 +930,23 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, StateMachineActivatedLinkDownMux
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
 }
 
+TEST_F(LinkManagerStateMachineActiveActiveTest, StateMachineActivatedLinkDownMuxActive)
+{
+    activateStateMachine();
+    VALIDATE_STATE(Wait, Wait, Down);
+
+    handleMuxState("active", 3);
+    VALIDATE_STATE(Wait, Active, Down);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    VALIDATE_STATE(Unknown, Standby, Down);
+
+    handleMuxState("active", 3);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    VALIDATE_STATE(Unknown, Standby, Down);
+}
+
 } /* namespace test */


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to address the scenario when
InitState:  ycabled reports -> active
InitState:  link state -> down 
handleStateChange: LinkProber -> unknown
compositeState: (unknown,active,down)

Expected behavior is toggling to standby, but the state transition handler is missed in today’s code

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->