### PR TITLE
Support link to swss logger

### DIFF
--- a/src/LinkMgrdMain.cpp
+++ b/src/LinkMgrdMain.cpp
@@ -45,12 +45,12 @@ namespace {
 
     static auto DEFAULT_LOGGING_FILTER_LEVEL = boost::log::trivial::debug;
 
-    void InitializeLogger(std::string execName, boost::log::trivial::severity_level level, bool extraLogFile)
+    void InitializeLogger(std::string execName, boost::log::trivial::severity_level level, bool extraLogFile, bool linkToSwssLogger)
     {
         std::string progName = execName.substr(execName.find_last_of('/') + 1);
         std::string logFile = "/var/log/mux/" + progName + ".log";
 
-        common::MuxLogger::getInstance()->initialize(progName, logFile, level, extraLogFile);
+        common::MuxLogger::getInstance()->initialize(progName, logFile, level, extraLogFile, linkToSwssLogger);
     }
 
 } // end namespace
@@ -70,6 +70,7 @@ int main(int argc, const char* argv[])
     bool extraLogFile = false;
     bool measureSwitchover = false;
     bool defaultRoute = false;
+    bool linkToSwssLogger = false;
 
     program_options::options_description description("linkmgrd options");
     description.add_options()
@@ -78,7 +79,7 @@ int main(int argc, const char* argv[])
         ("verbosity,v",
          program_options::value<boost::log::trivial::severity_level>(&level)->value_name("<severity_level>")->
          default_value(DEFAULT_LOGGING_FILTER_LEVEL),
-         "Logging verbosity level.")
+         "Boost logging verbosity level.")
         ("extra_log_file,e",
          program_options::bool_switch(&extraLogFile)->default_value(false),
          "Store logs in an extra log file")
@@ -88,6 +89,11 @@ int main(int argc, const char* argv[])
          ("default_route,d",
          program_options::bool_switch(&defaultRoute)->default_value(false),
          "Disable heartbeat sending and avoid switching to active when default route is missing"
+         )
+        ("link_to_swss_logger,l",
+         program_options::bool_switch(&linkToSwssLogger)->default_value(false),
+         "Link to swss logger instead of using native boost syslog support, this will"
+         "set the boost logging level to TRACE and option verbosity is ignored"
          )
     ;
 
@@ -117,7 +123,7 @@ int main(int argc, const char* argv[])
     }
 
     if (retValue == EXIT_SUCCESS) {
-        InitializeLogger(argv[0], level, extraLogFile);
+        InitializeLogger(argv[0], level, extraLogFile, linkToSwssLogger);
         std::stringstream ss;
         ss << "level: " << level;
         MUXLOGINFO(ss.str());

--- a/src/common/MuxLogger.cpp
+++ b/src/common/MuxLogger.cpp
@@ -27,9 +27,11 @@
 #include "boost/log/utility/setup/from_settings.hpp"
 #include <boost/log/utility/exception_handler.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "MuxException.h"
 #include "MuxLogger.h"
+#include "SwssLogBackend.h"
 
 namespace common
 {
@@ -87,33 +89,48 @@ void MuxLogger::initialize(
     std::string &prog,
     std::string &path,
     boost::log::trivial::severity_level level,
-    bool extraLogFile
+    bool extraLogFile,
+    bool linkToSwssLogger
 )
 {
     namespace trivial = boost::log::trivial;
-    namespace keywords = boost::log::keywords;
-
-    mLevel = level;
 
     boost::log::register_simple_formatter_factory<trivial::severity_level, char> ("Severity");
 
     boost::log::settings settings;
     boost::log::init_from_settings(settings);
 
-    if (extraLogFile) {
-        boost::filesystem::remove(path);
-        boost::log::add_file_log(
-            keywords::file_name = path,
-            keywords::format = "[%TimeStamp%] [%Severity%] %Message%"
-        );
-    }
-
     boost::log::add_common_attributes();
     boost::log::core::get()->set_exception_handler(
         boost::log::make_exception_handler<boost::log::runtime_error, std::exception> (MuxLoggerExceptionHandler())
     );
 
-    addSyslogSink(prog);
+    mLinkToSwssLogger = linkToSwssLogger;
+
+    if (linkToSwssLogger) {
+        // Setting the mux logger to the most verbose level to
+        // send all logs received by boost logger to swss logger
+        mLevel = boost::log::trivial::severity_level::trace;
+        mMuxLoggerEarlyStageFilterPtr = boost::bind(
+            &MuxLogger::isLogAcceptedBySwssLogger,
+            this,
+            boost::placeholders::_1
+        );
+        swss::Logger::linkToDbNative("linkmgrd");
+        addSwssSyslogSink(prog);
+    } else {
+        mLevel = level;
+        mMuxLoggerEarlyStageFilterPtr = boost::bind(
+            &MuxLogger::isLogAcceptedByBoostLogger,
+            this,
+            boost::placeholders::_1
+        );
+        addSyslogSink(prog);
+    }
+
+    if (extraLogFile) {
+        addExtraLogFileSink(prog, path);
+    }
 }
 
 //
@@ -123,10 +140,38 @@ void MuxLogger::initialize(
 //
 void MuxLogger::setLevel(const boost::log::trivial::severity_level level)
 {
+    if (mLinkToSwssLogger) {
+        MUXLOGERROR("Setting boost logger level is not supported when link to swss logger.");
+        return;
+    }
     namespace trivial = boost::log::trivial;
 
     mLevel = level;
     boost::log::core::get()->set_filter(trivial::severity >= level);
+}
+
+//
+// ---> addExtraLogFileSink(std::string &prog, const std::string &logFile);
+//
+// Add an extra log file sink
+//
+void MuxLogger::addExtraLogFileSink(std::string &prog, const std::string &logFile)
+{
+    namespace keywords = boost::log::keywords;
+
+    try {
+        boost::filesystem::remove(logFile);
+        boost::log::add_file_log(
+            keywords::file_name = logFile,
+            keywords::format = "[%TimeStamp%] [%Severity%] %Message%"
+        );
+    }
+    catch (std::exception& ex) {
+        std::ostringstream errMsg;
+        errMsg << "MUX Logger exception!!" << ". Exception details: " << ex.what();
+
+        throw MUX_ERROR(MuxLogger, errMsg.str());
+   }
 }
 
 //
@@ -149,7 +194,7 @@ void MuxLogger::addSyslogSink(std::string &prog)
         mapping[boost::log::trivial::trace] = sinks::syslog::debug;
         mapping[boost::log::trivial::debug] = sinks::syslog::debug;
         mapping[boost::log::trivial::info] = sinks::syslog::info;
-        mapping[boost::log::trivial::warning] = sinks::syslog::warning;
+        mapping[boost::log::trivial::warning] = sinks::syslog::notice;
         mapping[boost::log::trivial::error] = sinks::syslog::error;
         mapping[boost::log::trivial::fatal] = sinks::syslog::alert;
         sink->set_severity_mapper(mapping);
@@ -163,6 +208,46 @@ void MuxLogger::addSyslogSink(std::string &prog)
 
         throw MUX_ERROR(MuxLogger, errMsg.str());
    }
+}
+
+//
+// ---> addSwssSyslogSink(std::string &prog);
+//
+// Add swss syslog sink
+//
+void MuxLogger::addSwssSyslogSink(std::string &prog)
+{
+    namespace sinks = boost::log::sinks;
+    try {
+        boost::shared_ptr<SwssSyslogBackend> sink(new SwssSyslogBackend());
+        boost::log::core::get()->add_sink(boost::make_shared<sinks::synchronous_sink<SwssSyslogBackend>> (sink));
+    }
+    catch (std::exception& ex) {
+        std::ostringstream errMsg;
+        errMsg << "MUX Logger exception!!" << ". Exception details: " << ex.what();
+
+        throw MUX_ERROR(MuxLogger, errMsg.str());
+   }
+}
+
+//
+// ---> isLogAcceptedByBoostLogger(boost::log::trivial::severity_level level);
+//
+// early stage log level check in log macros to see if log is accepted by native boost logger
+//
+bool MuxLogger::isLogAcceptedByBoostLogger(boost::log::trivial::severity_level level)
+{
+    return level >= getLevel();
+}
+
+//
+// ---> isLogAcceptedBySwssLogger(boost::log::trivial::severity_level level);
+//
+// Early stage log level check in log macros to see if log is accepted by swss logger
+//
+bool MuxLogger::isLogAcceptedBySwssLogger(boost::log::trivial::severity_level level)
+{
+    return level >= mBoostLogLevelMapper[swss::Logger::getMinPrio()];
 }
 
 } /* namespace common */

--- a/src/common/SwssLogBackend.cpp
+++ b/src/common/SwssLogBackend.cpp
@@ -1,0 +1,102 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "SwssLogBackend.h"
+
+namespace common
+{
+
+//
+// ---> SwssSyslogBackend();
+//
+// class Constructor
+//
+SwssSyslogBackend::SwssSyslogBackend()
+    : mSwssLogger(swss::Logger::getInstance())
+{
+    namespace sinks = boost::log::sinks;
+    sinks::syslog::custom_severity_mapping<boost_log_level> mapping("Severity");
+    mapping[boost::log::trivial::trace] = boost_syslog_level::debug;
+    mapping[boost::log::trivial::debug] = boost_syslog_level::debug;
+    mapping[boost::log::trivial::info] = boost_syslog_level::info;
+    mapping[boost::log::trivial::warning] = boost_syslog_level::notice;
+    mapping[boost::log::trivial::error] = boost_syslog_level::error;
+    mapping[boost::log::trivial::fatal] = boost_syslog_level::alert;
+
+    set_severity_mapper(mapping);
+}
+
+//
+// ---> set_severity_mapper(const severity_mapper_type& mapper)
+//
+// set the mapping from boost log severity to syslog level
+//
+void SwssSyslogBackend::set_severity_mapper(const severity_mapper_type& mapper)
+{
+    mLevelMapper = mapper;
+}
+
+//
+// ---> consume(const boost::log::record_view& record,
+//              const string_type& formatted_message);
+//
+// write the message to the sink
+//
+void SwssSyslogBackend::consume(const boost::log::record_view& record, const string_type& formatted_message)
+{
+    boost_syslog_level level = mLevelMapper(record);
+    send(level, formatted_message);
+}
+
+//
+// ---> send(boost_syslog_level level,
+//           const string_type& formatted_message);
+//
+// write the message swss logger
+//
+void SwssSyslogBackend::send(boost_syslog_level level, const string_type& formatted_message)
+{
+    switch (level) {
+        case boost_syslog_level::debug:
+            swss::Logger::getInstance().write(swss::Logger::SWSS_DEBUG, formatted_message.c_str());
+            break;
+        case boost_syslog_level::info:
+            swss::Logger::getInstance().write(swss::Logger::SWSS_INFO, formatted_message.c_str());
+            break;
+        case boost_syslog_level::notice:
+            swss::Logger::getInstance().write(swss::Logger::SWSS_NOTICE, formatted_message.c_str());
+            break;
+        case boost_syslog_level::warning:
+            swss::Logger::getInstance().write(swss::Logger::SWSS_WARN, formatted_message.c_str());
+            break;
+        case boost_syslog_level::error:
+            swss::Logger::getInstance().write(swss::Logger::SWSS_ERROR, formatted_message.c_str());
+            break;
+        case boost_syslog_level::critical:
+            swss::Logger::getInstance().write(swss::Logger::SWSS_CRIT, formatted_message.c_str());
+            break;
+        case boost_syslog_level::alert:
+            swss::Logger::getInstance().write(swss::Logger::SWSS_ALERT, formatted_message.c_str());
+            break;
+        case boost_syslog_level::emergency:
+            swss::Logger::getInstance().write(swss::Logger::SWSS_EMERG, formatted_message.c_str());
+            break;
+        default:
+            break;
+    }
+}
+
+} /* namespace common */

--- a/src/common/SwssLogBackend.h
+++ b/src/common/SwssLogBackend.h
@@ -1,0 +1,99 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef SWSSLOGBACKEND_H_
+#define SWSSLOGBACKEND_H_
+
+#include <boost/log/sinks/basic_sink_backend.hpp>
+#include <boost/log/sinks/syslog_backend.hpp>
+#include <boost/log/trivial.hpp>
+
+#include "swss/logger.h"
+
+namespace common
+{
+
+class SwssSyslogBackend : public boost::log::sinks::basic_formatted_sink_backend<char>
+{
+public:
+    typedef boost::log::sinks::syslog_backend::char_type char_type;
+    typedef boost::log::sinks::syslog_backend::string_type string_type;
+    typedef boost::log::sinks::syslog_backend::severity_mapper_type severity_mapper_type;
+    typedef boost::log::sinks::syslog::level boost_syslog_level;
+    typedef boost::log::trivial::severity_level boost_log_level;
+
+public:
+    /**
+     *@method ~SwssSyslogBackend
+     *
+     *@brief class constructor
+     *
+     */
+    SwssSyslogBackend();
+
+    /**
+     *@method ~SwssSyslogBackend
+     *
+     *@brief class destructor
+     *
+     */
+    ~SwssSyslogBackend() = default;
+
+    /**
+     *@method set_severity_mapper
+     *
+     *@brief set the mapping from boost log severity to syslog level
+     *
+     *@param mapper (in)                severity mapping
+     *
+     *@return none
+     */
+    void set_severity_mapper(const severity_mapper_type& mapper);
+
+    /**
+     *@method consume
+     *
+     *@brief write the message to the sink
+     *
+     *@param record (in)                boost log record entry
+     *
+     *@param formatted_messgaes (in)    formatted log string of the record
+     *
+     *@return none
+     */
+    void consume(const boost::log::record_view& record, const string_type& formatted_message);
+
+private:
+    /**
+     *@method send
+     *
+     *@brief write the message swss logger
+     *
+     *@param level (in)                 syslog level
+     *
+     *@param formatted_messgaes (in)    formatted log string of the record
+     *
+     *@return none
+     */
+    inline void send(boost_syslog_level level, const string_type& formatted_message);
+
+    severity_mapper_type mLevelMapper;
+    swss::Logger &mSwssLogger;
+};
+
+} /* namespace common */
+
+#endif /* SWSSLOGBACKEND_H_ */

--- a/src/common/subdir.mk
+++ b/src/common/subdir.mk
@@ -3,19 +3,22 @@ CPP_SRCS += \
     ./src/common/MuxLogger.cpp \
     ./src/common/MuxPortConfig.cpp \
     ./src/common/State.cpp \
-    ./src/common/StateMachine.cpp 
+    ./src/common/StateMachine.cpp \
+    ./src/common/SwssLogBackend.cpp
 
 OBJS += \
     ./src/common/MuxLogger.o \
     ./src/common/MuxPortConfig.o \
     ./src/common/State.o \
-    ./src/common/StateMachine.o 
+    ./src/common/StateMachine.o \
+    ./src/common/SwssLogBackend.o
 
 CPP_DEPS += \
     ./src/common/MuxLogger.d \
     ./src/common/MuxPortConfig.d \
     ./src/common/State.d \
-    ./src/common/StateMachine.d 
+    ./src/common/StateMachine.d \
+    ./src/common/SwssLogBackend.d
 
 
 # Each subdirectory must supply rules for building sources it contributes


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Integrate `linkmgrd` with swss logger.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. Add a swss logger sink `SwssSyslogBackend` to support redirect all logs from `linkmgrd` to swss logger.
With this change, `linkmgrd` now supports three sinks:
* native syslog
* swss logger
* extra log file
2. Add an extra option `-link_to_swss_logger` or `-l` to `linkmgrd` to use swss logger sink.

#### How did you verify/test it?
Manual test in lab:
```
$ swssloglevel -p | grep linkmgrd
linkmgrd                      NOTICE
```

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->