### PR TITLE
Support linking to swss logger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,8 +101,8 @@ jobs:
       path: '$(Build.SourcesDirectory)/sonic-swss-common'
     displayName: "Download sonic swss common deb packages"
   - script: |
-      sudo dpkg -i sonic-swss-common.bullseye.amd64/libswsscommon_1.0.0_amd64.deb
-      sudo dpkg -i sonic-swss-common.bullseye.amd64/libswsscommon-dev_1.0.0_amd64.deb
+      sudo dpkg -i sonic-swss-common/libswsscommon_1.0.0_amd64.deb
+      sudo dpkg -i sonic-swss-common/libswsscommon-dev_1.0.0_amd64.deb
     displayName: "Install sonic swss common"
   - script: |
       rm ../*.deb
@@ -124,30 +124,30 @@ jobs:
   timeoutInMinutes: 180
   pool: sonicbld-arm64
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-buster-arm64:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bullseye-arm64:latest
 
   steps:
   - script: |
       set -ex
       sudo apt-get update
       sudo apt-get install -y\
-          libboost1.71-dev \
-          libboost-program-options1.71-dev \
-          libboost-system1.71-dev \
-          libboost-thread1.71-dev \
-          libboost-atomic1.71-dev \
-          libboost-chrono1.71-dev \
-          libboost-container1.71-dev \
-          libboost-context1.71-dev \
-          libboost-contract1.71-dev \
-          libboost-coroutine1.71-dev \
-          libboost-date-time1.71-dev \
-          libboost-fiber1.71-dev \
-          libboost-filesystem1.71-dev \
-          libboost-graph-parallel1.71-dev \
-          libboost-log1.71-dev \
-          libboost-regex1.71-dev \
-          libboost-serialization1.71-dev \
+          libboost-dev \
+          libboost-program-options-dev \
+          libboost-system-dev \
+          libboost-thread-dev \
+          libboost-atomic-dev \
+          libboost-chrono-dev \
+          libboost-container-dev \
+          libboost-context-dev \
+          libboost-contract-dev \
+          libboost-coroutine-dev \
+          libboost-date-time-dev \
+          libboost-fiber-dev \
+          libboost-filesystem-dev \
+          libboost-graph-parallel-dev \
+          libboost-log-dev \
+          libboost-regex-dev \
+          libboost-serialization-dev \
           googletest \
           libgtest-dev \
           libhiredis0.14 \
@@ -194,11 +194,7 @@ jobs:
       pipeline: 9
       artifact: sonic-swss-common.arm64
       runVersion: 'latestFromBranch'
-<<<<<<< HEAD
       runBranch: 'refs/heads/$(sourceBranch)'
-=======
-      runBranch: 'refs/heads/master'
->>>>>>> fix azp
       path: '$(Build.SourcesDirectory)/sonic-swss-common.arm64'
     displayName: "Download sonic swss common deb packages"
   - script: |
@@ -220,30 +216,30 @@ jobs:
   timeoutInMinutes: 180
   pool: sonicbld-armhf
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-buster-armhf:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bullseye-armhf:latest
 
   steps:
   - script: |
       set -ex
       sudo apt-get update
       sudo apt-get install -y \
-          libboost1.71-dev \
-          libboost-program-options1.71-dev \
-          libboost-system1.71-dev \
-          libboost-thread1.71-dev \
-          libboost-atomic1.71-dev \
-          libboost-chrono1.71-dev \
-          libboost-container1.71-dev \
-          libboost-context1.71-dev \
-          libboost-contract1.71-dev \
-          libboost-coroutine1.71-dev \
-          libboost-date-time1.71-dev \
-          libboost-fiber1.71-dev \
-          libboost-filesystem1.71-dev \
-          libboost-graph-parallel1.71-dev \
-          libboost-log1.71-dev \
-          libboost-regex1.71-dev \
-          libboost-serialization1.71-dev \
+          libboost-dev \
+          libboost-program-options-dev \
+          libboost-system-dev \
+          libboost-thread-dev \
+          libboost-atomic-dev \
+          libboost-chrono-dev \
+          libboost-container-dev \
+          libboost-context-dev \
+          libboost-contract-dev \
+          libboost-coroutine-dev \
+          libboost-date-time-dev \
+          libboost-fiber-dev \
+          libboost-filesystem-dev \
+          libboost-graph-parallel-dev \
+          libboost-log-dev \
+          libboost-regex-dev \
+          libboost-serialization-dev \
           googletest \
           libgtest-dev \
           libhiredis0.14 \
@@ -290,11 +286,7 @@ jobs:
       pipeline: 9
       artifact: sonic-swss-common.armhf
       runVersion: 'latestFromBranch'
-<<<<<<< HEAD
       runBranch: 'refs/heads/$(sourceBranch)'
-=======
-      runBranch: 'refs/heads/master'
->>>>>>> fix azp
       path: '$(Build.SourcesDirectory)/sonic-swss-common.armhf'
     displayName: "Download sonic swss common deb packages"
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,8 +101,8 @@ jobs:
       path: '$(Build.SourcesDirectory)/sonic-swss-common'
     displayName: "Download sonic swss common deb packages"
   - script: |
-      sudo dpkg -i sonic-swss-common/libswsscommon_1.0.0_amd64.deb
-      sudo dpkg -i sonic-swss-common/libswsscommon-dev_1.0.0_amd64.deb
+      sudo dpkg -i sonic-swss-common.bullseye.amd64/libswsscommon_1.0.0_amd64.deb
+      sudo dpkg -i sonic-swss-common.bullseye.amd64/libswsscommon-dev_1.0.0_amd64.deb
     displayName: "Install sonic swss common"
   - script: |
       rm ../*.deb
@@ -124,30 +124,30 @@ jobs:
   timeoutInMinutes: 180
   pool: sonicbld-arm64
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bullseye-arm64:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-buster-arm64:latest
 
   steps:
   - script: |
       set -ex
       sudo apt-get update
       sudo apt-get install -y\
-          libboost-dev \
-          libboost-program-options-dev \
-          libboost-system-dev \
-          libboost-thread-dev \
-          libboost-atomic-dev \
-          libboost-chrono-dev \
-          libboost-container-dev \
-          libboost-context-dev \
-          libboost-contract-dev \
-          libboost-coroutine-dev \
-          libboost-date-time-dev \
-          libboost-fiber-dev \
-          libboost-filesystem-dev \
-          libboost-graph-parallel-dev \
-          libboost-log-dev \
-          libboost-regex-dev \
-          libboost-serialization-dev \
+          libboost1.71-dev \
+          libboost-program-options1.71-dev \
+          libboost-system1.71-dev \
+          libboost-thread1.71-dev \
+          libboost-atomic1.71-dev \
+          libboost-chrono1.71-dev \
+          libboost-container1.71-dev \
+          libboost-context1.71-dev \
+          libboost-contract1.71-dev \
+          libboost-coroutine1.71-dev \
+          libboost-date-time1.71-dev \
+          libboost-fiber1.71-dev \
+          libboost-filesystem1.71-dev \
+          libboost-graph-parallel1.71-dev \
+          libboost-log1.71-dev \
+          libboost-regex1.71-dev \
+          libboost-serialization1.71-dev \
           googletest \
           libgtest-dev \
           libhiredis0.14 \
@@ -194,7 +194,11 @@ jobs:
       pipeline: 9
       artifact: sonic-swss-common.arm64
       runVersion: 'latestFromBranch'
+<<<<<<< HEAD
       runBranch: 'refs/heads/$(sourceBranch)'
+=======
+      runBranch: 'refs/heads/master'
+>>>>>>> fix azp
       path: '$(Build.SourcesDirectory)/sonic-swss-common.arm64'
     displayName: "Download sonic swss common deb packages"
   - script: |
@@ -216,30 +220,30 @@ jobs:
   timeoutInMinutes: 180
   pool: sonicbld-armhf
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bullseye-armhf:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-buster-armhf:latest
 
   steps:
   - script: |
       set -ex
       sudo apt-get update
       sudo apt-get install -y \
-          libboost-dev \
-          libboost-program-options-dev \
-          libboost-system-dev \
-          libboost-thread-dev \
-          libboost-atomic-dev \
-          libboost-chrono-dev \
-          libboost-container-dev \
-          libboost-context-dev \
-          libboost-contract-dev \
-          libboost-coroutine-dev \
-          libboost-date-time-dev \
-          libboost-fiber-dev \
-          libboost-filesystem-dev \
-          libboost-graph-parallel-dev \
-          libboost-log-dev \
-          libboost-regex-dev \
-          libboost-serialization-dev \
+          libboost1.71-dev \
+          libboost-program-options1.71-dev \
+          libboost-system1.71-dev \
+          libboost-thread1.71-dev \
+          libboost-atomic1.71-dev \
+          libboost-chrono1.71-dev \
+          libboost-container1.71-dev \
+          libboost-context1.71-dev \
+          libboost-contract1.71-dev \
+          libboost-coroutine1.71-dev \
+          libboost-date-time1.71-dev \
+          libboost-fiber1.71-dev \
+          libboost-filesystem1.71-dev \
+          libboost-graph-parallel1.71-dev \
+          libboost-log1.71-dev \
+          libboost-regex1.71-dev \
+          libboost-serialization1.71-dev \
           googletest \
           libgtest-dev \
           libhiredis0.14 \
@@ -286,7 +290,11 @@ jobs:
       pipeline: 9
       artifact: sonic-swss-common.armhf
       runVersion: 'latestFromBranch'
+<<<<<<< HEAD
       runBranch: 'refs/heads/$(sourceBranch)'
+=======
+      runBranch: 'refs/heads/master'
+>>>>>>> fix azp
       path: '$(Build.SourcesDirectory)/sonic-swss-common.armhf'
     displayName: "Download sonic swss common deb packages"
   - script: |

--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -1030,7 +1030,9 @@ void DbInterface::processMuxLinkmgrConfigNotifiction(std::deque<swss::KeyOpField
                 std::string f = fvField(fieldValue);
                 std::string v = fvValue(fieldValue);
                 if (f == "log_verbosity") {
-                    mMuxManagerPtr->updateLogVerbosity(v);
+                    if (!common::MuxLogger::getInstance()->isLinkToSwssLogger()) {
+                        mMuxManagerPtr->updateLogVerbosity(v);
+                    }
                 }
 
                 MUXLOGINFO(boost::format("key: %s, Operation: %s, f: %s, v: %s") %

--- a/src/LinkMgrdMain.cpp
+++ b/src/LinkMgrdMain.cpp
@@ -45,12 +45,12 @@ namespace {
 
     static auto DEFAULT_LOGGING_FILTER_LEVEL = boost::log::trivial::debug;
 
-    void InitializeLogger(std::string execName, boost::log::trivial::severity_level level, bool extraLogFile)
+    void InitializeLogger(std::string execName, boost::log::trivial::severity_level level, bool extraLogFile, bool linkToSwssLogger)
     {
         std::string progName = execName.substr(execName.find_last_of('/') + 1);
         std::string logFile = "/var/log/mux/" + progName + ".log";
 
-        common::MuxLogger::getInstance()->initialize(progName, logFile, level, extraLogFile);
+        common::MuxLogger::getInstance()->initialize(progName, logFile, level, extraLogFile, linkToSwssLogger);
     }
 
 } // end namespace
@@ -70,6 +70,7 @@ int main(int argc, const char* argv[])
     bool extraLogFile = false;
     bool measureSwitchover = false;
     bool defaultRoute = false;
+    bool linkToSwssLogger = false;
 
     program_options::options_description description("linkmgrd options");
     description.add_options()
@@ -78,7 +79,7 @@ int main(int argc, const char* argv[])
         ("verbosity,v",
          program_options::value<boost::log::trivial::severity_level>(&level)->value_name("<severity_level>")->
          default_value(DEFAULT_LOGGING_FILTER_LEVEL),
-         "Logging verbosity level.")
+         "Boost logging verbosity level.")
         ("extra_log_file,e",
          program_options::bool_switch(&extraLogFile)->default_value(false),
          "Store logs in an extra log file")
@@ -88,6 +89,11 @@ int main(int argc, const char* argv[])
          ("default_route,d",
          program_options::bool_switch(&defaultRoute)->default_value(false),
          "Disable heartbeat sending and avoid switching to active when default route is missing"
+         )
+        ("link_to_swss_logger,l",
+         program_options::bool_switch(&linkToSwssLogger)->default_value(false),
+         "Link to swss logger instead of using native boost syslog support, this will"
+         "set the boost logging level to TRACE and option verbosity is ignored"
          )
     ;
 
@@ -117,7 +123,7 @@ int main(int argc, const char* argv[])
     }
 
     if (retValue == EXIT_SUCCESS) {
-        InitializeLogger(argv[0], level, extraLogFile);
+        InitializeLogger(argv[0], level, extraLogFile, linkToSwssLogger);
         std::stringstream ss;
         ss << "level: " << level;
         MUXLOGINFO(ss.str());

--- a/src/common/MuxLogger.cpp
+++ b/src/common/MuxLogger.cpp
@@ -128,10 +128,10 @@ void MuxLogger::initialize(
     mLinkToSwssLogger = linkToSwssLogger;
 
     if (linkToSwssLogger) {
+        addSwssSyslogSink(prog);
         // default to "NOTICE" when linking to swss log level
         startSwssLogger("NOTICE");
         mLevel = boost::log::trivial::warning;
-        addSwssSyslogSink(prog);
     } else {
         addSyslogSink(prog);
     }

--- a/src/common/MuxLogger.h
+++ b/src/common/MuxLogger.h
@@ -24,13 +24,16 @@
 #ifndef MUXLOGGER_H_
 #define MUXLOGGER_H_
 
+#include <map>
 #include <memory>
 
 #include <boost/format.hpp>
 #include <boost/log/exceptions.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/log/sources/severity_logger.hpp>
+#include <boost/log/sinks/syslog_backend.hpp>
 
+#include "swss/logger.h"
 
 namespace common
 {
@@ -105,18 +108,43 @@ public:
     static MuxLoggerPtr getInstance();
 
     /**
+     *@method swssPrioNotify
+     *
+     *@brief process syslog priority setting from swssloglevel
+     *
+     *@param component (in)    program name
+     *@param prioStr (in)      syslog log level string
+     *
+     *@return None
+     */
+    static void swssPrioNotify(const std::string& component, const std::string& prioStr);
+
+    /**
+     *@method swssOutputNotify
+     *
+     *@brief process syslog output setting from swssloglevel, only support syslog
+     *
+     *@param component (in)     program name
+     *@param outputStr (in)     syslog log output destination
+     *
+     *@return None
+     */
+    static void swssOutputNotify(const std::string& component, const std::string& outputStr);
+
+    /**
     *@method initialize
     *
     *@brief initialize MUX logging class
     *
-    *@param prog (in)           program name to be used when logging
-    *@param path (in)           path on file system to MUX logging file
-    *@param level (in)          minimum logging severity level
-    *@param extraLogFile (in)   save log in an extra log file
+    *@param prog (in)               program name to be used when logging
+    *@param path (in)               path on file system to MUX logging file
+    *@param level (in)              minimum logging severity level
+    *@param extraLogFile (in)       save log in an extra log file
+    *@param linkToSwssLogger (in)   output log to swss logger
     *
     *@return none
     */
-    void initialize(std::string &prog, std::string &path, boost::log::trivial::severity_level level, bool extraLogFile);
+    void initialize(std::string &prog, std::string &path, boost::log::trivial::severity_level level, bool extraLogFile, bool linkToSwsslogger=false);
 
     /**
     *@method setLevel
@@ -160,9 +188,42 @@ private:
     */
     MuxLogger() = default;
 
+    /**
+    *@method addExtraLogFileSink
+    *
+    *@brief Add an extra log file sink
+    *
+    *@return none
+    */
+    void addExtraLogFileSink(std::string &prog, const std::string &logFile);
+
+    /**
+    *@method addSyslogSink
+    *
+    *@brief add boost syslog sink to the logger
+    *
+    *@return none
+    */
     void addSyslogSink(std::string &prog);
 
+    /**
+    *@method addSwssSyslogSink
+    *
+    *@brief add swss syslog sink to the logger
+    *
+    *@return none
+    */
+    void addSwssSyslogSink(std::string &prog);
+
 private:
+    typedef std::map<boost::log::sinks::syslog::level, boost::log::trivial::severity_level> BoostLogLevelMap;
+    static const BoostLogLevelMap mBoostLogLevelMapper;
+
+    typedef std::map<boost::log::trivial::severity_level, boost::log::sinks::syslog::level> SyslogLevelMap;
+    static const SyslogLevelMap mSyslogLevelMapper;
+
+private:
+    bool mLinkToSwssLogger = false;
     boost::log::trivial::severity_level mLevel = boost::log::trivial::info;
 
     boost::log::sources::severity_logger_mt<boost::log::trivial::severity_level> mSeverityLogger;

--- a/src/common/MuxLogger.h
+++ b/src/common/MuxLogger.h
@@ -35,6 +35,10 @@
 
 #include "swss/logger.h"
 
+namespace test {
+class MuxLoggerTest;
+}
+
 namespace common
 {
 class MuxLogger;
@@ -108,30 +112,6 @@ public:
     static MuxLoggerPtr getInstance();
 
     /**
-     *@method swssPrioNotify
-     *
-     *@brief process syslog priority setting from swssloglevel
-     *
-     *@param component (in)    program name
-     *@param prioStr (in)      syslog log level string
-     *
-     *@return None
-     */
-    static void swssPrioNotify(const std::string& component, const std::string& prioStr);
-
-    /**
-     *@method swssOutputNotify
-     *
-     *@brief process syslog output setting from swssloglevel, only support syslog
-     *
-     *@param component (in)     program name
-     *@param outputStr (in)     syslog log output destination
-     *
-     *@return None
-     */
-    static void swssOutputNotify(const std::string& component, const std::string& outputStr);
-
-    /**
     *@method initialize
     *
     *@brief initialize MUX logging class
@@ -176,8 +156,51 @@ public:
     boost::log::sources::severity_logger_mt<boost::log::trivial::severity_level>&
     getLogger() {return mSeverityLogger;};
 
+    /**
+    *@method startSwssLogger
+    *
+    *@brief start swss logger
+    *
+    *@return None
+    */
+    virtual void startSwssLogger(const std::string &swssPrio);
+
+    /**
+     *@method swssPrioNotify
+     *
+     *@brief process syslog priority setting from swssloglevel
+     *
+     *@param component (in)    program name
+     *@param prioStr (in)      syslog log level string
+     *
+     *@return None
+     */
+    void swssPrioNotify(std::string component, std::string prioStr);
+
+    /**
+     *@method swssOutputNotify
+     *
+     *@brief process syslog output setting from swssloglevel, only support syslog
+     *
+     *@param component (in)     program name
+     *@param outputStr (in)     syslog log output destination
+     *
+     *@return None
+     */
+    void swssOutputNotify(std::string component, std::string outputStr);
+
+    /**
+    *@method isLinkToSwssLogger
+    *
+    *@brief return if mux logger is linked to swss logger
+    *
+    *@return None
+    */
+    bool isLinkToSwssLogger() { return mLinkToSwssLogger; };
+
 private:
     friend class std::shared_ptr<MuxLogger>;
+    friend class test::MuxLoggerTest;
     friend MuxLoggerPtr std::make_shared<MuxLogger> ();
 
     /**

--- a/src/common/MuxLogger.h
+++ b/src/common/MuxLogger.h
@@ -194,7 +194,7 @@ public:
     *
     *@brief return if mux logger is linked to swss logger
     *
-    *@return None
+    *@return true if swss logger is linked
     */
     bool isLinkToSwssLogger() { return mLinkToSwssLogger; };
 

--- a/src/common/SwssLogBackend.cpp
+++ b/src/common/SwssLogBackend.cpp
@@ -59,34 +59,7 @@ void SwssSyslogBackend::consume(const boost::log::record_view& record, const str
 //
 void SwssSyslogBackend::send(boost_syslog_level level, const string_type& formatted_message)
 {
-    switch (level) {
-        case boost_syslog_level::debug:
-            mSwssLogger.write(swss::Logger::SWSS_DEBUG, formatted_message.c_str());
-            break;
-        case boost_syslog_level::info:
-            mSwssLogger.write(swss::Logger::SWSS_INFO, formatted_message.c_str());
-            break;
-        case boost_syslog_level::notice:
-            mSwssLogger.write(swss::Logger::SWSS_NOTICE, formatted_message.c_str());
-            break;
-        case boost_syslog_level::warning:
-            mSwssLogger.write(swss::Logger::SWSS_WARN, formatted_message.c_str());
-            break;
-        case boost_syslog_level::error:
-            mSwssLogger.write(swss::Logger::SWSS_ERROR, formatted_message.c_str());
-            break;
-        case boost_syslog_level::critical:
-            mSwssLogger.write(swss::Logger::SWSS_CRIT, formatted_message.c_str());
-            break;
-        case boost_syslog_level::alert:
-            mSwssLogger.write(swss::Logger::SWSS_ALERT, formatted_message.c_str());
-            break;
-        case boost_syslog_level::emergency:
-            mSwssLogger.write(swss::Logger::SWSS_EMERG, formatted_message.c_str());
-            break;
-        default:
-            break;
-    }
+    mSwssLogger.write(static_cast<swss::Logger::Priority>(level), formatted_message.c_str());
 }
 
 } /* namespace common */

--- a/src/common/SwssLogBackend.cpp
+++ b/src/common/SwssLogBackend.cpp
@@ -1,0 +1,92 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "SwssLogBackend.h"
+
+namespace common
+{
+
+//
+// ---> SwssSyslogBackend();
+//
+// class Constructor
+//
+SwssSyslogBackend::SwssSyslogBackend()
+    : mSwssLogger(swss::Logger::getInstance())
+{
+}
+
+//
+// ---> set_severity_mapper(const severity_mapper_type& mapper)
+//
+// set the mapping from boost log severity to syslog level
+//
+void SwssSyslogBackend::set_severity_mapper(const severity_mapper_type& mapper)
+{
+    mLevelMapper = mapper;
+}
+
+//
+// ---> consume(const boost::log::record_view& record,
+//              const string_type& formatted_message);
+//
+// write the message to the sink
+//
+void SwssSyslogBackend::consume(const boost::log::record_view& record, const string_type& formatted_message)
+{
+    boost_syslog_level level = mLevelMapper(record);
+    send(level, formatted_message);
+}
+
+//
+// ---> send(boost_syslog_level level,
+//           const string_type& formatted_message);
+//
+// write the message swss logger
+//
+void SwssSyslogBackend::send(boost_syslog_level level, const string_type& formatted_message)
+{
+    switch (level) {
+        case boost_syslog_level::debug:
+            mSwssLogger.write(swss::Logger::SWSS_DEBUG, formatted_message.c_str());
+            break;
+        case boost_syslog_level::info:
+            mSwssLogger.write(swss::Logger::SWSS_INFO, formatted_message.c_str());
+            break;
+        case boost_syslog_level::notice:
+            mSwssLogger.write(swss::Logger::SWSS_NOTICE, formatted_message.c_str());
+            break;
+        case boost_syslog_level::warning:
+            mSwssLogger.write(swss::Logger::SWSS_WARN, formatted_message.c_str());
+            break;
+        case boost_syslog_level::error:
+            mSwssLogger.write(swss::Logger::SWSS_ERROR, formatted_message.c_str());
+            break;
+        case boost_syslog_level::critical:
+            mSwssLogger.write(swss::Logger::SWSS_CRIT, formatted_message.c_str());
+            break;
+        case boost_syslog_level::alert:
+            mSwssLogger.write(swss::Logger::SWSS_ALERT, formatted_message.c_str());
+            break;
+        case boost_syslog_level::emergency:
+            mSwssLogger.write(swss::Logger::SWSS_EMERG, formatted_message.c_str());
+            break;
+        default:
+            break;
+    }
+}
+
+} /* namespace common */

--- a/src/common/SwssLogBackend.h
+++ b/src/common/SwssLogBackend.h
@@ -1,0 +1,99 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef SWSSLOGBACKEND_H_
+#define SWSSLOGBACKEND_H_
+
+#include <boost/log/sinks/basic_sink_backend.hpp>
+#include <boost/log/sinks/syslog_backend.hpp>
+#include <boost/log/trivial.hpp>
+
+#include "swss/logger.h"
+
+namespace common
+{
+
+class SwssSyslogBackend : public boost::log::sinks::basic_formatted_sink_backend<char>
+{
+public:
+    typedef boost::log::sinks::syslog_backend::char_type char_type;
+    typedef boost::log::sinks::syslog_backend::string_type string_type;
+    typedef boost::log::sinks::syslog_backend::severity_mapper_type severity_mapper_type;
+    typedef boost::log::sinks::syslog::level boost_syslog_level;
+    typedef boost::log::trivial::severity_level boost_log_level;
+
+public:
+    /**
+     *@method ~SwssSyslogBackend
+     *
+     *@brief class constructor
+     *
+     */
+    SwssSyslogBackend();
+
+    /**
+     *@method ~SwssSyslogBackend
+     *
+     *@brief class destructor
+     *
+     */
+    ~SwssSyslogBackend() = default;
+
+    /**
+     *@method set_severity_mapper
+     *
+     *@brief set the mapping from boost log severity to syslog level
+     *
+     *@param mapper (in)                severity mapping
+     *
+     *@return none
+     */
+    void set_severity_mapper(const severity_mapper_type& mapper);
+
+    /**
+     *@method consume
+     *
+     *@brief write the message to the sink
+     *
+     *@param record (in)                boost log record entry
+     *
+     *@param formatted_messgaes (in)    formatted log string of the record
+     *
+     *@return none
+     */
+    void consume(const boost::log::record_view& record, const string_type& formatted_message);
+
+private:
+    /**
+     *@method send
+     *
+     *@brief write the message swss logger
+     *
+     *@param level (in)                 syslog level
+     *
+     *@param formatted_messgaes (in)    formatted log string of the record
+     *
+     *@return none
+     */
+    inline void send(boost_syslog_level level, const string_type& formatted_message);
+
+    severity_mapper_type mLevelMapper;
+    swss::Logger& mSwssLogger;
+};
+
+} /* namespace common */
+
+#endif /* SWSSLOGBACKEND_H_ */

--- a/src/common/subdir.mk
+++ b/src/common/subdir.mk
@@ -3,19 +3,22 @@ CPP_SRCS += \
     ./src/common/MuxLogger.cpp \
     ./src/common/MuxPortConfig.cpp \
     ./src/common/State.cpp \
-    ./src/common/StateMachine.cpp 
+    ./src/common/StateMachine.cpp \
+    ./src/common/SwssLogBackend.cpp
 
 OBJS += \
     ./src/common/MuxLogger.o \
     ./src/common/MuxPortConfig.o \
     ./src/common/State.o \
-    ./src/common/StateMachine.o 
+    ./src/common/StateMachine.o \
+    ./src/common/SwssLogBackend.o
 
 CPP_DEPS += \
     ./src/common/MuxLogger.d \
     ./src/common/MuxPortConfig.d \
     ./src/common/State.d \
-    ./src/common/StateMachine.d 
+    ./src/common/StateMachine.d \
+    ./src/common/SwssLogBackend.d
 
 
 # Each subdirectory must supply rules for building sources it contributes

--- a/test/MuxLoggerTest.cpp
+++ b/test/MuxLoggerTest.cpp
@@ -1,0 +1,113 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include "common/MuxLogger.h"
+#include "MuxLoggerTest.h"
+
+using ::testing::_;
+
+namespace test
+{
+
+void MuxLoggerTest::initializeLogger(
+    std::string &prog, std::string &path, boost::log::trivial::severity_level level, bool extraLogFile, bool linkToSwsslogger
+)
+{
+    initialize(
+        prog,
+        path,
+        level,
+        extraLogFile,
+        linkToSwsslogger
+    );
+}
+
+void MuxLoggerTest::startSwssLogger(const std::string &swssPrio)
+{
+    mSwssLoggerStarted = true;
+    mInitSwssPrioStr = swssPrio;
+}
+
+TEST_F(MuxLoggerTest, LinkToSwssLogger)
+{
+    std::string prog = "linkmgrd";
+    std::string path = "";
+    boost::log::trivial::severity_level muxLoggerLevel;
+    swss::Logger::Priority swssLoggerLevel;
+
+    initializeLogger(prog, path, boost::log::trivial::fatal, false, true);
+
+    EXPECT_TRUE(isSwssLoggerStarted());
+    EXPECT_EQ(getInitialSwssLogPrioStr(), "NOTICE");
+
+    swssPrioNotify(prog, getInitialSwssLogPrioStr());
+    swssLoggerLevel = swss::Logger::getMinPrio();
+    muxLoggerLevel = getLevel();
+    EXPECT_EQ(swssLoggerLevel, swss::Logger::SWSS_NOTICE);
+    EXPECT_EQ(muxLoggerLevel, boost::log::trivial::warning);
+
+    swssPrioNotify(prog, "EMERG");
+    swssLoggerLevel = swss::Logger::getMinPrio();
+    muxLoggerLevel = getLevel();
+    EXPECT_EQ(swssLoggerLevel, swss::Logger::SWSS_EMERG);
+    EXPECT_EQ(muxLoggerLevel, boost::log::trivial::fatal);
+
+    swssPrioNotify(prog, "ALERT");
+    swssLoggerLevel = swss::Logger::getMinPrio();
+    muxLoggerLevel = getLevel();
+    EXPECT_EQ(swssLoggerLevel, swss::Logger::SWSS_ALERT);
+    EXPECT_EQ(muxLoggerLevel, boost::log::trivial::fatal);
+
+    swssPrioNotify(prog, "CRIT");
+    swssLoggerLevel = swss::Logger::getMinPrio();
+    muxLoggerLevel = getLevel();
+    EXPECT_EQ(swssLoggerLevel, swss::Logger::SWSS_CRIT);
+    EXPECT_EQ(muxLoggerLevel, boost::log::trivial::error);
+
+    swssPrioNotify(prog, "ERROR");
+    swssLoggerLevel = swss::Logger::getMinPrio();
+    muxLoggerLevel = getLevel();
+    EXPECT_EQ(swssLoggerLevel, swss::Logger::SWSS_ERROR);
+    EXPECT_EQ(muxLoggerLevel, boost::log::trivial::error);
+
+    swssPrioNotify(prog, "WARN");
+    swssLoggerLevel = swss::Logger::getMinPrio();
+    muxLoggerLevel = getLevel();
+    EXPECT_EQ(swssLoggerLevel, swss::Logger::SWSS_WARN);
+    EXPECT_EQ(muxLoggerLevel, boost::log::trivial::warning);
+
+    swssPrioNotify(prog, "NOTICE");
+    swssLoggerLevel = swss::Logger::getMinPrio();
+    muxLoggerLevel = getLevel();
+    EXPECT_EQ(swssLoggerLevel, swss::Logger::SWSS_NOTICE);
+    EXPECT_EQ(muxLoggerLevel, boost::log::trivial::warning);
+
+    swssPrioNotify(prog, "INFO");
+    swssLoggerLevel = swss::Logger::getMinPrio();
+    muxLoggerLevel = getLevel();
+    EXPECT_EQ(swssLoggerLevel, swss::Logger::SWSS_INFO);
+    EXPECT_EQ(muxLoggerLevel, boost::log::trivial::info);
+
+    swssPrioNotify(prog, "DEBUG");
+    swssLoggerLevel = swss::Logger::getMinPrio();
+    muxLoggerLevel = getLevel();
+    EXPECT_EQ(swssLoggerLevel, swss::Logger::SWSS_DEBUG);
+    EXPECT_EQ(muxLoggerLevel, boost::log::trivial::trace);
+}
+
+} /* namespace test */

--- a/test/MuxLoggerTest.cpp
+++ b/test/MuxLoggerTest.cpp
@@ -19,8 +19,6 @@
 #include "common/MuxLogger.h"
 #include "MuxLoggerTest.h"
 
-using ::testing::_;
-
 namespace test
 {
 

--- a/test/MuxLoggerTest.h
+++ b/test/MuxLoggerTest.h
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef MUXLOGGERTEST_H_
+#define MUXLOGGERTEST_H_
+
+#include <memory>
+
+#include "common/MuxLogger.h"
+#include "gtest/gtest.h"
+
+namespace test
+{
+
+class MuxLoggerTest : public testing::Test, public common::MuxLogger
+{
+public:
+    MuxLoggerTest() = default;
+    virtual ~MuxLoggerTest() = default;
+    void initializeLogger(std::string &prog, std::string &path, boost::log::trivial::severity_level level, bool extraLogFile, bool linkToSwsslogger = false);
+    void startSwssLogger(const std::string &swssPrio) override;
+    bool isSwssLoggerStarted() { return mSwssLoggerStarted; }
+    const std::string getInitialSwssLogPrioStr() { return mInitSwssPrioStr; }
+
+private:
+    bool mSwssLoggerStarted = false;
+    std::string mInitSwssPrioStr;
+};
+
+} /* namespace test */
+
+#endif /* MUXLOGGERTEST_H_ */

--- a/test/subdir.mk
+++ b/test/subdir.mk
@@ -9,7 +9,8 @@ CPP_SRCS += \
     ./test/MuxManagerTest.cpp \
     ./test/MockLinkManagerStateMachine.cpp \
     ./test/MockLinkProberTest.cpp \
-    ./test/LinkMgrdTestMain.cpp
+    ./test/LinkMgrdTestMain.cpp \
+    ./test/MuxLoggerTest.cpp
 
 OBJS_LINKMGRD_TEST += \
     ./test/FakeDbInterface.o \
@@ -21,7 +22,8 @@ OBJS_LINKMGRD_TEST += \
     ./test/MuxManagerTest.o \
     ./test/MockLinkManagerStateMachine.o \
     ./test/MockLinkProberTest.o \
-    ./test/LinkMgrdTestMain.o
+    ./test/LinkMgrdTestMain.o \
+    ./test/MuxLoggerTest.o
 
 CPP_DEPS += \
     ./test/FakeDbInterface.d \
@@ -33,7 +35,8 @@ CPP_DEPS += \
     ./test/MuxManagerTest.d \
     ./test/MockLinkManagerStateMachine.d \
     ./test/MockLinkProberTest.d \
-    ./test/LinkMgrdTestMain.d
+    ./test/LinkMgrdTestMain.d \
+    ./test/MuxLoggerTest.d
 
 # Each subdirectory must supply rules for building sources it contributes
 test/%.o: test/%.cpp


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To support linking to swss logger.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


#### How did you do it?
1. add a dedicated sink `SwssSyslogBackend` to direct all logs from mux logger to swss logger.
2. add custom log db observer to receive log level changes from `swssloglevel`
    * This depends on: https://github.com/sonic-net/sonic-swss-common/pull/766

#### How did you verify/test it?
Manual validation on the testbed.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->