### PR TITLE
[active-standby] avoid unnecessary mux state probe after configuring to `auto`

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -778,8 +778,7 @@ void ActiveStandbyStateMachine::handleMuxConfigNotification(const common::MuxPor
                 LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
                 mCompositeState = nextState;
             } else {
-                mMuxStateMachine.setWaitStateCause(mux_state::WaitState::WaitStateCause::DriverUpdate);
-                mMuxPortPtr->probeMuxState();
+                startMuxProbeTimer();
             }
         }
 

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -415,6 +415,9 @@ TEST_F(LinkManagerStateMachineTest, MuxActiveCliAuto)
 
     handleMuxConfig("auto");
     VALIDATE_STATE(Active, Active, Up);
+
+    runIoService(2);
+    EXPECT_EQ(mDbInterfacePtr->mProbeMuxStateInvokeCount, 0);
 }
 
 TEST_F(LinkManagerStateMachineTest, MuxAStandbyCliAuto)
@@ -423,6 +426,9 @@ TEST_F(LinkManagerStateMachineTest, MuxAStandbyCliAuto)
 
     handleMuxConfig("auto");
     VALIDATE_STATE(Standby, Standby, Up);
+
+    runIoService(2);
+    EXPECT_EQ(mDbInterfacePtr->mProbeMuxStateInvokeCount, 0);
 }
 
 TEST_F(LinkManagerStateMachineTest, MuxActiveCliManual)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Issue was found in recent upgrade: ycable firmware would return `active` or `standby` to both sides. Hence one side limkgrd state will be `unhealthy` and block upgrade. 

This PR is to unblock upgrade by avoiding an immediate mux probe. Instead, wait for 300ms and if there is an inconsistency then, probe mux state. 

Cable firmware update or fix is out of the scope of this PR. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Unblock production upgrade. 

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->