### PR TITLE
[active-standby] Enforce switchover based on heartbeats when mux probe keeps failing

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -47,7 +47,7 @@ std::vector<std::string> DbInterface::mMuxState = {"active", "standby", "unknown
 std::vector<std::string> DbInterface::mMuxLinkmgrState = {"uninitialized", "unhealthy", "healthy"};
 std::vector<std::string> DbInterface::mMuxMetrics = {"start", "end"};
 std::vector<std::string> DbInterface::mLinkProbeMetrics = {"link_prober_unknown_start", "link_prober_unknown_end", "link_prober_wait_start", "link_prober_active_start", "link_prober_standby_start"};
-std::vector<std::string> DbInterface::mActiveStandbySwitchCause = {"Peer_Heartbeat_Missing" , "Peer_Link_Down" , "Tlv_Switch_Active_Command" , "Link_Down" , "Transceiver_Daemon_Timeout" , "Matching_Hardware_State" , "Config_Mux_Mode"};
+std::vector<std::string> DbInterface::mActiveStandbySwitchCause = {"Peer_Heartbeat_Missing" , "Peer_Link_Down" , "Tlv_Switch_Active_Command" , "Link_Down" , "Transceiver_Daemon_Timeout" , "Matching_Hardware_State" , "Config_Mux_Mode", "Hardware_State_Unknown"};
 
 //
 // ---> DbInterface(mux::MuxManager *muxManager);

--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -234,7 +234,7 @@ void DbInterface::handlePostSwitchCause(
         boost::posix_time::ptime time
 )
 {
-    MUXLOGDEBUG(boost::format("%s: post switch cause %s") %
+    MUXLOGWARNING(boost::format("%s: post last switch cause %s") %
         portName %
         mActiveStandbySwitchCause[static_cast<int>(cause)]
     );

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -460,10 +460,14 @@ void ActiveStandbyStateMachine::handleStateChange(LinkProberEvent &event, link_p
         
         if (state == link_prober::LinkProberState::Label::Active) {
             mMuxPortPtr->postLinkProberMetricsEvent(link_manager::ActiveStandbyStateMachine::LinkProberMetrics::LinkProberActiveStart);
+
+            mStandbyUnknownUpCount = 0;
         }
          
         if (state == link_prober::LinkProberState::Label::Standby) {
             mMuxPortPtr->postLinkProberMetricsEvent(link_manager::ActiveStandbyStateMachine::LinkProberMetrics::LinkProberStandbyStart);
+
+            mActiveUnknownUpCount = 0;
         }
 
         CompositeState nextState = mCompositeState;
@@ -553,6 +557,9 @@ void ActiveStandbyStateMachine::handleStateChange(LinkStateEvent &event, link_st
                    ms(mCompositeState) != mux_state::MuxState::Label::Standby) {
             // switch MUX to standby since we are entering LinkDown state
             switchMuxState(link_manager::ActiveStandbyStateMachine::SwitchCause::LinkDown, nextState, mux_state::MuxState::Label::Standby);
+
+            mActiveUnknownUpCount = 0;
+            mStandbyUnknownUpCount = 0;
         } else {
             mStateTransitionHandler[ps(nextState)][ms(nextState)][ls(nextState)](nextState);
         }

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -1155,11 +1155,7 @@ void ActiveStandbyStateMachine::LinkProberActiveMuxUnknownLinkUpTransitionFuncti
     MUXLOGINFO(mMuxPortConfig.getPortName());
 
     mActiveUnknownUpCount++;
-    MUXLOGWARNING(boost::format("%s: mActiveUnknownUpCount %d mStandbyUnknownUpCount %d") %
-        mMuxPortConfig.getPortName() %
-        mActiveUnknownUpCount % 
-        mStandbyUnknownUpCount
-    );
+
     if (mActiveUnknownUpCount == 2) {
         switchMuxState(link_manager::ActiveStandbyStateMachine::SwitchCause::HarewareStateUnknown, nextState, mux_state::MuxState::Label::Active);
     } else {
@@ -1179,11 +1175,7 @@ void ActiveStandbyStateMachine::LinkProberStandbyMuxUnknownLinkUpTransitionFunct
     MUXLOGINFO(mMuxPortConfig.getPortName());
 
     mStandbyUnknownUpCount++;
-    MUXLOGWARNING(boost::format("%s: mActiveUnknownUpCount %d mStandbyUnknownUpCount %d") %
-        mMuxPortConfig.getPortName() %
-        mActiveUnknownUpCount % 
-        mStandbyUnknownUpCount
-    );
+
     if ((ps(mCompositeState) != ps(nextState)) &&
         (ps(nextState) == link_prober::LinkProberState::Label::Active ||
          ps(nextState) == link_prober::LinkProberState::Label::Standby)) {

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -300,10 +300,9 @@ void ActiveStandbyStateMachine::switchMuxState(
 )
 {
     if (forceSwitch || mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto) {
-        MUXLOGWARNING(boost::format("%s: Switching MUX state to '%s' for casue: %s") %
+        MUXLOGWARNING(boost::format("%s: Switching MUX state to '%s'") %
             mMuxPortConfig.getPortName() %
-            mMuxStateName[label],
-            mux::DbInterface::mActiveStandbySwitchCause[cause]
+            mMuxStateName[label]
         );
 
         // mWaitActiveUpCount is introduced to address asymmetric link drop issue. 

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -520,7 +520,7 @@ void ActiveStandbyStateMachine::handleStateChange(MuxStateEvent &event, mux_stat
         }
     }
 
-    if (ms(mCompositeState) != mux_state::MuxState::Unknown) {
+    if (state != mux_state::MuxState::Label::Unknown) {
         mMuxUnknownBackoffFactor = 1;
 
         mActiveUnknownUpCount = 0;
@@ -1155,6 +1155,11 @@ void ActiveStandbyStateMachine::LinkProberActiveMuxUnknownLinkUpTransitionFuncti
     MUXLOGINFO(mMuxPortConfig.getPortName());
 
     mActiveUnknownUpCount++;
+    MUXLOGWARNING(boost::format("%s: mActiveUnknownUpCount %d mStandbyUnknownUpCount %d") %
+        mMuxPortConfig.getPortName() %
+        mActiveUnknownUpCount % 
+        mStandbyUnknownUpCount
+    );
     if (mActiveUnknownUpCount == 2) {
         switchMuxState(link_manager::ActiveStandbyStateMachine::SwitchCause::HarewareStateUnknown, nextState, mux_state::MuxState::Label::Active);
     } else {
@@ -1174,7 +1179,11 @@ void ActiveStandbyStateMachine::LinkProberStandbyMuxUnknownLinkUpTransitionFunct
     MUXLOGINFO(mMuxPortConfig.getPortName());
 
     mStandbyUnknownUpCount++;
-    
+    MUXLOGWARNING(boost::format("%s: mActiveUnknownUpCount %d mStandbyUnknownUpCount %d") %
+        mMuxPortConfig.getPortName() %
+        mActiveUnknownUpCount % 
+        mStandbyUnknownUpCount
+    );
     if ((ps(mCompositeState) != ps(nextState)) &&
         (ps(nextState) == link_prober::LinkProberState::Label::Active ||
          ps(nextState) == link_prober::LinkProberState::Label::Standby)) {

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -1156,7 +1156,7 @@ void ActiveStandbyStateMachine::LinkProberActiveMuxUnknownLinkUpTransitionFuncti
 
     mActiveUnknownUpCount++;
 
-    if (mActiveUnknownUpCount == 2) {
+    if (mActiveUnknownUpCount == mMuxPortConfig.getNegativeStateChangeRetryCount()) {
         switchMuxState(link_manager::ActiveStandbyStateMachine::SwitchCause::HarewareStateUnknown, nextState, mux_state::MuxState::Label::Active);
     } else {
         enterMuxWaitState(nextState);
@@ -1180,7 +1180,7 @@ void ActiveStandbyStateMachine::LinkProberStandbyMuxUnknownLinkUpTransitionFunct
         (ps(nextState) == link_prober::LinkProberState::Label::Active ||
          ps(nextState) == link_prober::LinkProberState::Label::Standby)) {
         enterMuxWaitState(nextState);
-    } else if (mStandbyUnknownUpCount == 2) {
+    } else if (mStandbyUnknownUpCount == mMuxPortConfig.getNegativeStateChangeRetryCount()) {
         switchMuxState(link_manager::ActiveStandbyStateMachine::SwitchCause::HarewareStateUnknown, nextState, mux_state::MuxState::Label::Standby);
     } else {
         startMuxProbeTimer();

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -72,6 +72,7 @@ public:
         TransceiverDaemonTimeout,
         MatchingHardwareState,
         ConfigMuxMode,
+        HarewareStateUnknown,
 
         Count
     };
@@ -835,6 +836,8 @@ private:
     boost::function<void ()> mRevertIntervalFnPtr;
 
     uint32_t mWaitActiveUpCount = 0;
+    uint32_t mActiveUnknownUpCount = 0;
+    uint32_t mStandbyUnknownUpCount = 0;
     uint32_t mMuxUnknownBackoffFactor = 1;
     uint32_t mWaitStandbyUpBackoffFactor = 1;
     uint32_t mUnknownActiveUpBackoffFactor = 1;

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -888,10 +888,10 @@ TEST_F(LinkManagerStateMachineTest, StandbyStateToProberUnknownMuxUnknownLinkUp)
     runIoService(2);
     VALIDATE_STATE(Unknown, Wait, Up);
 
-    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
     handleProbeMuxState("standby", 3);
     VALIDATE_STATE(Wait, Wait, Up);
-    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
 
     // swss notification
     handleMuxState("unknown", 3);
@@ -957,10 +957,10 @@ TEST_F(LinkManagerStateMachineTest, ProberWaitMuxUnknownLinkDown)
     runIoService(2);
     VALIDATE_STATE(Unknown, Wait, Up);
 
-    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 0);
     handleProbeMuxState("standby", 3);
     VALIDATE_STATE(Wait, Wait, Up);
-    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
 
     // swss notification
     handleMuxState("unknown", 3);
@@ -1290,6 +1290,9 @@ TEST_F(LinkManagerStateMachineTest, CableFirmwareFailure)
     handleProbeMuxState("unknown", 4);
     VALIDATE_STATE(Standby, Wait, Up);
 
+    handleProbeMuxState("unknown", 4);
+    VALIDATE_STATE(Standby, Wait, Up);
+
     runIoService(2);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
     EXPECT_EQ(mDbInterfacePtr->mLastPostedSwitchCause, link_manager::ActiveStandbyStateMachine::SwitchCause::HarewareStateUnknown);
@@ -1299,6 +1302,9 @@ TEST_F(LinkManagerStateMachineTest, CableFirmwareFailure)
     VALIDATE_STATE(Active, Wait, Up);
 
     postMuxEvent(mux_state::MuxState::Unknown, 3);
+    VALIDATE_STATE(Active, Wait, Up);
+
+    handleProbeMuxState("unknown", 4);
     VALIDATE_STATE(Active, Wait, Up);
 
     handleProbeMuxState("unknown", 4);

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1290,6 +1290,7 @@ TEST_F(LinkManagerStateMachineTest, CableFirmwareFailure)
     handleProbeMuxState("unknown", 4);
     VALIDATE_STATE(Standby, Wait, Up);
 
+    runIoService(2);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
     EXPECT_EQ(mDbInterfacePtr->mLastPostedSwitchCause, link_manager::ActiveStandbyStateMachine::SwitchCause::HarewareStateUnknown);
 
@@ -1303,6 +1304,7 @@ TEST_F(LinkManagerStateMachineTest, CableFirmwareFailure)
     handleProbeMuxState("unknown", 4);
     VALIDATE_STATE(Active, Wait, Up);
 
+    runIoService(2);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
     EXPECT_EQ(mDbInterfacePtr->mLastPostedSwitchCause, link_manager::ActiveStandbyStateMachine::SwitchCause::HarewareStateUnknown);
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Fixing a common issue in production. Root cause is bad firmware failing to respond to mux toggle or mux query. 

For example, in below senario, we will have two `standby` ToRs in the end, both sides will have tunnel-route installed. 
``` 
UT0: active -> toggle standby -> toggles succeeds -> healthy 
LT0: standby > receive heartbeat event active due to peer's toggle -> probe mux state -> mux state unknown -> probe mux state -> repeating ...
```
The traffic loss in this scenario is evitable, as heartbeat behavior is very consistent and from that linkmgrd should be table to tell the current mux direction. 

The solution is when mux probing is the **ONLY** failing component, linkmgrd enforce a switchover based on heartbeat status. To ensure the heartbeat behaviour is consistent, we count how many times we enter the composite state **continuously**. 

sign-off: Jing Zhang zhangjing@microsoft.com 
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Minimize traffic loss. 

#### How did you do it?

#### How did you verify/test it?
Tested on dualtor DUT, with mux-simulator off. 
1. Toggle `active`
2. Toggle `standby`

Tunnel route was fixed into "one side active, one side standby" state. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->