### PR TITLE
[202012] Avoid unnecessary error logs from `handleGetServerMacAddressNotification` #96

### DIFF
--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -629,7 +629,7 @@ void LinkManagerStateMachine::handleGetServerMacAddressNotification(std::array<u
         mMuxPortConfig.setBladeMacAddress(address);
         if (mUpdateEthernetFrameFnPtr) {
             mUpdateEthernetFrameFnPtr();
-        } else {
+        } else if (mComponentInitState.test(LinkProberComponent)) {
             std::array<char, 3 * ETHER_ADDR_LEN> addressStr = {0};
             snprintf(
                 addressStr.data(), addressStr.size(), "%02x:%02x:%02x:%02x:%02x:%02x",

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -97,6 +97,11 @@ uint32_t MuxManagerTest::getLinkWaitTimeout_msec(std::string port)
     return muxPortPtr->mMuxPortConfig.getLinkWaitTimeout_msec();
 }
 
+bool MuxManagerTest::setUseWellKnownMacActiveActive(bool use)
+{
+    mMuxManagerPtr->setUseWellKnownMacActiveActive(use);
+}
+
 boost::asio::ip::address MuxManagerTest::getBladeIpv4Address(std::string port)
 {
     std::shared_ptr<mux::MuxPort> muxPortPtr = mMuxManagerPtr->mPortMap[port];
@@ -306,6 +311,15 @@ void MuxManagerTest::createPort(std::string port)
     EXPECT_TRUE(linkManagerStateMachine->mComponentInitState.test(link_manager::LinkManagerStateMachine::MuxStateComponent) == 1);
 }
 
+void MuxManagerTest::resetUpdateEthernetFrameFn(const std::string &portName)
+{
+    std::shared_ptr<mux::MuxPort> muxPortPtr = mMuxManagerPtr->mPortMap[portName];
+    std::shared_ptr<link_manager::LinkManagerStateMachineBase> linkManagerStateMachine = muxPortPtr->getLinkManagerStateMachinePtr();
+
+    boost::function<void()> fnPtr = NULL;
+    linkManagerStateMachine->setUpdateEthernetFrameFnPtr(fnPtr);
+}
+
 TEST_F(MuxManagerTest, AddPort)
 {
     std::string port = "Ethernet0";
@@ -436,6 +450,33 @@ TEST_F(MuxManagerTest, ServerMacAddressException)
     std::array<uint8_t, ETHER_ADDR_LEN> serverMacAfter = getBladeMacAddress(port);
 
     EXPECT_TRUE(serverMacBefore == serverMacAfter);
+}
+
+TEST_F(MuxManagerTest, ServerMacBeforeLinkProberInit)
+{
+    std::string port = "Ethernet0";
+    std::string ipAddress = "192.168.0.1";
+
+    createPort(port);
+    resetUpdateEthernetFrameFn(port);
+
+    std::string mac = "a0:1b:c2:3d:e4:5f";
+    std::array<char, MAX_ADDR_SIZE + 1> macAddress = {0};
+    memcpy(macAddress.data(), mac.c_str(), mac.size());
+    std::array<char, MAX_ADDR_SIZE + 1> serverIpAddress = {0};
+    memcpy(serverIpAddress.data(), ipAddress.c_str(), ipAddress.size());
+
+    processServerMacAddress(port, serverIpAddress, macAddress);
+
+    runIoService();
+
+    std::array<uint8_t, ETHER_ADDR_LEN> serverMac = getBladeMacAddress(port);
+
+    swss::MacAddress swssMacAddress(mac);
+    std::array<uint8_t, ETHER_ADDR_LEN> expectedMac;
+    memcpy(expectedMac.data(), swssMacAddress.getMac(), expectedMac.size());
+
+    EXPECT_TRUE(serverMac == expectedMac);
 }
 
 TEST_F(MuxManagerTest, LinkmgrdConfig)

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -97,11 +97,6 @@ uint32_t MuxManagerTest::getLinkWaitTimeout_msec(std::string port)
     return muxPortPtr->mMuxPortConfig.getLinkWaitTimeout_msec();
 }
 
-bool MuxManagerTest::setUseWellKnownMacActiveActive(bool use)
-{
-    mMuxManagerPtr->setUseWellKnownMacActiveActive(use);
-}
-
 boost::asio::ip::address MuxManagerTest::getBladeIpv4Address(std::string port)
 {
     std::shared_ptr<mux::MuxPort> muxPortPtr = mMuxManagerPtr->mPortMap[port];
@@ -314,7 +309,7 @@ void MuxManagerTest::createPort(std::string port)
 void MuxManagerTest::resetUpdateEthernetFrameFn(const std::string &portName)
 {
     std::shared_ptr<mux::MuxPort> muxPortPtr = mMuxManagerPtr->mPortMap[portName];
-    std::shared_ptr<link_manager::LinkManagerStateMachineBase> linkManagerStateMachine = muxPortPtr->getLinkManagerStateMachinePtr();
+    link_manager::LinkManagerStateMachine* linkManagerStateMachine = muxPortPtr->getLinkManagerStateMachine();
 
     boost::function<void()> fnPtr = NULL;
     linkManagerStateMachine->setUpdateEthernetFrameFnPtr(fnPtr);

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -53,6 +53,7 @@ public:
     uint32_t getTimeoutIpv4_msec(std::string port);
     uint32_t getTimeoutIpv6_msec(std::string port);
     uint32_t getLinkWaitTimeout_msec(std::string port);
+    bool setUseWellKnownMacActiveActive(bool use);
     boost::asio::ip::address getBladeIpv4Address(std::string port);
     std::array<uint8_t, ETHER_ADDR_LEN> getBladeMacAddress(std::string port);
     boost::asio::ip::address getLoopbackIpv4Address(std::string port);
@@ -71,6 +72,7 @@ public:
     void warmRestartReconciliation(const std::string &portName);
     void updatePortReconciliationCount(int increment);
     void startWarmRestartReconciliationTimer(uint32_t timeout);
+    void resetUpdateEthernetFrameFn(const std::string &portName);
     void postMetricsEvent(const std::string &portName, mux_state::MuxState::Label label);
     void setMuxState(const std::string &portName, mux_state::MuxState::Label label);
     void initializeThread();

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -53,7 +53,6 @@ public:
     uint32_t getTimeoutIpv4_msec(std::string port);
     uint32_t getTimeoutIpv6_msec(std::string port);
     uint32_t getLinkWaitTimeout_msec(std::string port);
-    bool setUseWellKnownMacActiveActive(bool use);
     boost::asio::ip::address getBladeIpv4Address(std::string port);
     std::array<uint8_t, ETHER_ADDR_LEN> getBladeMacAddress(std::string port);
     boost::asio::ip::address getLoopbackIpv4Address(std::string port);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Cherry-pick conflict: 
945b107 Jing Zhang      Thu Jul 21 10:16:53 2022 -0700  Avoid unnecessary error logs from `handleGetServerMacAddressNotification` (#96)

sign-off: Jing Zhang zhangjing@microsoft.com
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->