### PR TITLE
[202012] Fix build failure introduced by cherry-pick of #173

### DIFF
--- a/src/link_manager/LinkManagerStateMachine.cpp
+++ b/src/link_manager/LinkManagerStateMachine.cpp
@@ -830,7 +830,7 @@ void LinkManagerStateMachine::handleMuxConfigNotification(const common::MuxPortC
             if (ls(mCompositeState) == link_state::LinkState::Down &&
                 ms(mCompositeState) != mux_state::MuxState::Label::Standby) {
                 CompositeState nextState = mCompositeState;
-                switchMuxState(link_manager::ActiveStandbyStateMachine::SwitchCause::LinkDown, nextState, mux_state::MuxState::Label::Standby, true);
+                switchMuxState(link_manager::LinkManagerStateMachine::SwitchCause::LinkDown, nextState, mux_state::MuxState::Label::Standby, true);
                 LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
                 mCompositeState = nextState;
             } else {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

After cherry-picked PR https://github.com/sonic-net/sonic-linkmgrd/pull/173 into 202012 branch, the branch build started failing. 

It was because the commit introduced a reference to `ActiveStandbyStateMachine`: 
https://github.com/sonic-net/sonic-linkmgrd/blob/d893be9be2744ecd8bdbb0e3e102914d6ca32a55/src/link_manager/LinkManagerStateMachine.cpp#L833

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->