### PR TITLE
Ignore mux probe unknown for health calculation

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -176,6 +176,8 @@ void ActiveActiveStateMachine::handleMuxStateNotification(mux_state::MuxState::L
     MUXLOGWARNING(boost::format("%s: state db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
 
     mWaitTimer.cancel();
+
+    mLastMuxNotificationType = LastMuxNotificationType::MuxNotificationFromToggle;
     mLastMuxStateNotification = label;
 
     if (mComponentInitState.all()) {
@@ -265,6 +267,9 @@ void ActiveActiveStateMachine::handleMuxConfigNotification(const common::MuxPort
 void ActiveActiveStateMachine::handleProbeMuxStateNotification(mux_state::MuxState::Label label)
 {
     MUXLOGINFO(boost::format("%s: app db mux state: %s") % mMuxPortConfig.getPortName() % mMuxStateName[label]);
+
+    mLastMuxNotificationType = LastMuxNotificationType::MuxNotificationFromProbe;
+    mLastMuxProbeNotification = label;
 
     mWaitTimer.cancel();
     if (label == mux_state::MuxState::Label::Active || label == mux_state::MuxState::Label::Standby) {
@@ -1069,7 +1074,10 @@ void ActiveActiveStateMachine::updateMuxLinkmgrState()
     Label label = Label::Unhealthy;
     if (ls(mCompositeState) == link_state::LinkState::Label::Up &&
         ps(mCompositeState) == link_prober::LinkProberState::Label::Active &&
-        (ms(mCompositeState) == mLastMuxStateNotification || mLastMuxStateNotification == mux_state::MuxState::Label::Unknown) &&
+        (ms(mCompositeState) == mLastMuxStateNotification ||
+         mLastMuxStateNotification == mux_state::MuxState::Label::Unknown ||
+         (mLastMuxNotificationType == LastMuxNotificationType::MuxNotificationFromProbe &&
+          mLastMuxProbeNotification == mux_state::MuxState::Label::Unknown)) &&
         (mMuxPortConfig.ifEnableDefaultRouteFeature() == false || mDefaultRouteState == DefaultRoute::OK)) {
         label = Label::Healthy;
     }

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -690,11 +690,20 @@ private: // testing only
      */
     void setSendPeerProbeCommandFnPtr(boost::function<void()> sendPeerProbeCommandFnPtr) { mSendPeerProbeCommandFnPtr = sendPeerProbeCommandFnPtr; }
 
+private:
+    enum class LastMuxNotificationType {
+        MuxNotificationNotReceived,
+        MuxNotificationFromToggle,
+        MuxNotificationFromProbe,
+    };
+
 private: // peer link prober state and mux state
     link_prober::LinkProberState::Label mPeerLinkProberState = link_prober::LinkProberState::Label::PeerWait;
     mux_state::MuxState::Label mPeerMuxState = mux_state::MuxState::Label::Wait;
     mux_state::MuxState::Label mLastSetPeerMuxState = mux_state::MuxState::Label::Wait;
     mux_state::MuxState::Label mLastMuxStateNotification = mux_state::MuxState::Label::Unknown;
+    mux_state::MuxState::Label mLastMuxProbeNotification = mux_state::MuxState::Label::Unknown;
+    LastMuxNotificationType mLastMuxNotificationType = LastMuxNotificationType::MuxNotificationNotReceived;
 
 private:
     uint32_t mMuxProbeBackoffFactor = 1;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
If the mux is healthy(`active`, `active`, `up`), mux probe `unknown` will transit the mux into `unhealthy`.
Based on the mux health definition from PR: https://github.com/sonic-net/sonic-linkmgrd/pull/163, if the mux server is not responsive, the mux should remain healthy in such a case.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. if the mux port is healthy and the last mux notification is `unknown` from mux probe, ignore it in the health calculation.
2. add the healthy check in the periodical probe test case
3. add three more test case to cover more scenarios:
    * mux active, periodical probe unknown
    * mux standby, periodical probe active
    * mux standby, periodical probe unknown

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->