### PR TITLE
[active-active] Add mux server state correction mechanism

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -749,9 +749,9 @@ void ActiveActiveStateMachine::LinkProberActiveMuxActiveLinkUpTransitionFunction
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
     if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Standby) {
-        switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
-    } else if (ms(mCompositeState) != mux_state::MuxState::Active) {
-        switchMuxState(nextState, mux_state::MuxState::Label::Active);
+        if (mLastMuxStateNotification != mux_state::MuxState::Label::Standby) {
+            switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
+        }
     } else if (mLastMuxStateNotification == mux_state::MuxState::Label::Unknown) {
         // switch active to notify swss
         switchMuxState(nextState, mux_state::MuxState::Label::Active);
@@ -766,7 +766,14 @@ void ActiveActiveStateMachine::LinkProberActiveMuxActiveLinkUpTransitionFunction
 void ActiveActiveStateMachine::LinkProberActiveMuxStandbyLinkUpTransitionFunction(CompositeState &nextState)
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
-    switchMuxState(nextState, mux_state::MuxState::Label::Active);
+    if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Standby) {
+        if (mLastMuxStateNotification != mux_state::MuxState::Label::Standby) {
+            // last siwtch mux state to standby failed, try again
+            switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
+        }
+    } else {
+        switchMuxState(nextState, mux_state::MuxState::Label::Active);
+    }
 }
 
 //
@@ -777,9 +784,11 @@ void ActiveActiveStateMachine::LinkProberActiveMuxStandbyLinkUpTransitionFunctio
 void ActiveActiveStateMachine::LinkProberUnknownMuxActiveLinkUpTransitionFunction(CompositeState &nextState)
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
-    if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Active && mLastMuxStateNotification != mux_state::MuxState::Label::Active) {
-        // last switch mux state to active failed, try again
-        switchMuxState(nextState, mux_state::MuxState::Label::Active, true);
+    if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Active) {
+        if (mLastMuxStateNotification != mux_state::MuxState::Label::Active) {
+            // last switch mux state to active failed, try again
+            switchMuxState(nextState, mux_state::MuxState::Label::Active, true);
+        }
     } else {
         switchMuxState(nextState, mux_state::MuxState::Label::Standby);
     }
@@ -793,9 +802,14 @@ void ActiveActiveStateMachine::LinkProberUnknownMuxActiveLinkUpTransitionFunctio
 void ActiveActiveStateMachine::LinkProberUnknownMuxStandbyLinkUpTransitionFunction(CompositeState &nextState)
 {
     MUXLOGINFO(mMuxPortConfig.getPortName());
-    if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Active && mLastMuxStateNotification != mux_state::MuxState::Label::Active) {
-        // last switch mux state to active failed, try again
-        switchMuxState(nextState, mux_state::MuxState::Label::Active, true);
+    if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Active) {
+        if (mLastMuxStateNotification != mux_state::MuxState::Label::Active) {
+            // last switch mux state to active failed, try again
+            switchMuxState(nextState, mux_state::MuxState::Label::Active, true);
+        }
+    } else if (mLastMuxStateNotification == mux_state::MuxState::Label::Unknown) {
+        // switch standby to notify swss
+        switchMuxState(nextState, mux_state::MuxState::Label::Standby);
     }
 }
 

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -737,7 +737,7 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceMuxUnkown)
     EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, probeForwardingStateBefore + 2);
 }
 
-TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceConfigReloadMuxUnknown)
+TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceConfigReloadMuxUnknownLinkProberActive)
 {
     VALIDATE_STATE(Wait, Wait, Down);
     uint32_t probeForwardingStateBefore = mDbInterfacePtr->mProbeForwardingStateInvokeCount;
@@ -758,6 +758,47 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceConfigRelo
     VALIDATE_STATE(Active, Active, Up);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
     EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+
+    handleMuxState("unknown", 3);
+    VALIDATE_STATE(Active, Unknown, Up);
+    EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, probeForwardingStateBefore + 2);
+
+    handleProbeMuxState("active", 5);
+    VALIDATE_STATE(Active, Active, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, LinkmgrdBootupSequenceConfigReloadMuxUnknownLinkProberUnknown)
+{
+    VALIDATE_STATE(Wait, Wait, Down);
+    uint32_t probeForwardingStateBefore = mDbInterfacePtr->mProbeForwardingStateInvokeCount;
+
+    handleMuxState("unknown", 2);
+    VALIDATE_STATE(Wait, Wait, Down);
+    EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, probeForwardingStateBefore + 1);
+
+    activateStateMachine();
+
+    postLinkEvent(link_state::LinkState::Up);
+    VALIDATE_STATE(Wait, Wait, Up);
+
+    handleProbeMuxState("standby", 3);
+    VALIDATE_STATE(Wait, Standby, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Unknown, 3);
+    VALIDATE_STATE(Unknown, Standby, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+
+    handleMuxState("unknown", 3);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+    EXPECT_EQ(mDbInterfacePtr->mProbeForwardingStateInvokeCount, probeForwardingStateBefore + 2);
+
+    handleProbeMuxState("standby", 5);
+    VALIDATE_STATE(Unknown, Standby, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
 }
 
 TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveRecvMuxProbeTlv)
@@ -928,7 +969,7 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveConfigStandbygRPCError)
     VALIDATE_STATE(Active, Unknown, Up);
 }
 
-TEST_F(LinkManagerStateMachineActiveActiveTest, MuxStandbyConfigStandbygRPCError)
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxStandbyConfigActivegRPCError)
 {
     setMuxStandby();
 
@@ -956,6 +997,48 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxStandbyConfigStandbygRPCError
 
     handleMuxState("unknown", 4);
     VALIDATE_STATE(Unknown, Unknown, Up);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveConfigStandbygRPCErrorMuxProbeStandby)
+{
+    setMuxActive();
+
+    handleMuxConfig("standby", 1);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+    VALIDATE_STATE(Active, Standby, Up);
+
+    handleMuxState("unknown", 4);
+    VALIDATE_STATE(Active, Unknown, Up);
+
+    handleProbeMuxState("standby", 4);
+    VALIDATE_STATE(Active, Standby, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+
+    handleMuxState("standby", 4);
+    VALIDATE_STATE(Active, Standby, Up);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxStandbyConfigActivegRPCErrorMuxProbeActive)
+{
+    setMuxStandby();
+
+    handleMuxConfig("active", 1);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+    VALIDATE_STATE(Unknown, Active, Up);
+
+    handleMuxState("unknown", 4);
+    VALIDATE_STATE(Unknown, Unknown, Up);
+
+    handleProbeMuxState("active", 4);
+    VALIDATE_STATE(Unknown, Active, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+
+    handleMuxState("active", 4);
+    VALIDATE_STATE(Unknown, Active, Up);
 }
 
 TEST_F(LinkManagerStateMachineActiveActiveTest, StateMachineActivatedLinkDownLinkProberFirst)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

There is no uniform mux server state correction for the state machine in
case if the mux toggle fails at first(mux server state not expected).
Let's add an uniform mux server state correction that is compatible with
previous codes.

The basic idea is that, when the mux probe is able to return meaningful
mux states(`active` or `standby`), let's add a check to see if the last toggle
succeeded or not. So let's define our mux toggle decision process as the
following:

```
If mux config is active or standby:
    if last toggle success:
        NOOP
    else:
        toggle based on the mux config
else:
    if mux status not matches heartbeats:
        toggle based on heartbeats
    else:
        if last toggle success:
            NOOP
        else:
            toggle based on the heartbeats
```

As we only consider mux probe `active` or `standby`, so only four
transition functions needs to be improved:

LinkProberActiveMuxActiveLinkUpTransitionFunction
LinkProberActiveMuxStandbyLinkUpTransitionFunction
LinkProberUnknownMuxActiveLinkUpTransitionFunction
LinkProberUnknownMuxStandbyLinkUpTransitionFunction

NOTE: mux probe `unknown` is not covered as the primary goal is to
guarantee a toggle success. Mux server down after toggle is not a
sufficient reason for us to update the mux server status and break the
healthy state.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?

#### How did you verify/test it?
1. Add UT.
2. testbed verification
* with heartbeats, mux active -> config reload -> mux active consistently
* without heartbeats, mux standby -> config reload -> mux standby consistently
* with heartbeats, mux active -> mux config standby -> config save -> config reload -> mux standby consistently
* without hearbeats, mux standby -> mux config active -> config save -> config reload -> mux active consistently

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->