### PR TITLE
[202012] remove chatty log message for peer link event

### DIFF
--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -205,7 +205,7 @@ void MuxManager::addOrUpdateMuxPortLinkState(const std::string &portName, const 
 //
 void MuxManager::addOrUpdatePeerLinkState(const std::string &portName, const std::string &linkState)
 {
-    MUXLOGWARNING(boost::format("%s: peer link state %s") % portName % linkState);
+    MUXLOGDEBUG(boost::format("%s: peer link state %s") % portName % linkState);
 
     std::shared_ptr<MuxPort> muxPortPtr = getMuxPortPtrOrThrow(portName);
     muxPortPtr->handlePeerLinkState(linkState);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Remove chatty syslog message for peer link state. The state is updated by pmon every 30s even without changing. 

sign-off: Jing Zhang zhangjing@microsoft.com
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->