### PR TITLE
[202012][active-standby] Enforce switchover based on heartbeats when mux probe keeps failing #184

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,24 +75,6 @@ jobs:
     inputs:
       source: specific
       project: build
-      pipeline: Azure.sonic-buildimage.common_libs
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(sourceBranch)'
-      path: $(Build.ArtifactStagingDirectory)/download
-      artifact: common-lib
-      patterns: |
-        target/debs/buster/libyang-*.deb
-        target/debs/buster/libyang_*.deb
-    displayName: "Download libyang from common lib"
-  - script: |
-      set -ex
-      sudo dpkg -i $(find ./download -name *.deb)
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    displayName: "Install libyang from common lib"
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: specific
-      project: build
       pipeline: 9
       artifact: sonic-swss-common
       runVersion: 'latestFromBranch'
@@ -172,24 +154,6 @@ jobs:
     inputs:
       source: specific
       project: build
-      pipeline: Azure.sonic-buildimage.common_libs
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(sourceBranch)'
-      path: $(Build.ArtifactStagingDirectory)/download
-      artifact: common-lib.arm64
-      patterns: |
-        target/debs/buster/libyang-*.deb
-        target/debs/buster/libyang_*.deb
-    displayName: "Download libyang from common lib"
-  - script: |
-      set -ex
-      sudo dpkg -i $(find ./download -name *.deb)
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    displayName: "Install libyang from common lib"
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: specific
-      project: build
       pipeline: 9
       artifact: sonic-swss-common.arm64
       runVersion: 'latestFromBranch'
@@ -260,24 +224,6 @@ jobs:
       echo "Download artifact branch: $sourceBranch"
       echo "##vso[task.setvariable variable=sourceBranch]$sourceBranch"
     displayName: "Get correct artifact downloading branch"
-  - task: DownloadPipelineArtifact@2
-    inputs:
-      source: specific
-      project: build
-      pipeline: Azure.sonic-buildimage.common_libs
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/$(sourceBranch)'
-      path: $(Build.ArtifactStagingDirectory)/download
-      artifact: common-lib.armhf
-      patterns: |
-        target/debs/buster/libyang-*.deb
-        target/debs/buster/libyang_*.deb
-    displayName: "Download libyang from common lib"
-  - script: |
-      set -ex
-      sudo dpkg -i $(find ./download -name *.deb)
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    displayName: "Install libyang from common lib"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,13 +63,21 @@ jobs:
   - checkout: self
     clean: true
     submodules: true
+  - script: |
+      sourceBranch=$(Build.SourceBranchName)
+      if [[ "$(Build.Reason)" == "PullRequest" ]];then
+        sourceBranch=$(System.PullRequest.TargetBranch)
+      fi
+      echo "Download artifact branch: $sourceBranch"
+      echo "##vso[task.setvariable variable=sourceBranch]$sourceBranch"
+    displayName: "Get correct artifact downloading branch"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
       pipeline: Azure.sonic-buildimage.common_libs
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(sourceBranch)'
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |
@@ -88,7 +96,7 @@ jobs:
       pipeline: 9
       artifact: sonic-swss-common
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(sourceBranch)'
       path: '$(Build.SourcesDirectory)/sonic-swss-common'
     displayName: "Download sonic swss common deb packages"
   - script: |
@@ -152,13 +160,21 @@ jobs:
   - checkout: self
     clean: true
     submodules: true
+  - script: |
+      sourceBranch=$(Build.SourceBranchName)
+      if [[ "$(Build.Reason)" == "PullRequest" ]];then
+        sourceBranch=$(System.PullRequest.TargetBranch)
+      fi
+      echo "Download artifact branch: $sourceBranch"
+      echo "##vso[task.setvariable variable=sourceBranch]$sourceBranch"
+    displayName: "Get correct artifact downloading branch"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
       pipeline: Azure.sonic-buildimage.common_libs
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(sourceBranch)'
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib.arm64
       patterns: |
@@ -177,7 +193,7 @@ jobs:
       pipeline: 9
       artifact: sonic-swss-common.arm64
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(sourceBranch)'
       path: '$(Build.SourcesDirectory)/sonic-swss-common.arm64'
     displayName: "Download sonic swss common deb packages"
   - script: |
@@ -236,13 +252,21 @@ jobs:
   - checkout: self
     clean: true
     submodules: true
+  - script: |
+      sourceBranch=$(Build.SourceBranchName)
+      if [[ "$(Build.Reason)" == "PullRequest" ]];then
+        sourceBranch=$(System.PullRequest.TargetBranch)
+      fi
+      echo "Download artifact branch: $sourceBranch"
+      echo "##vso[task.setvariable variable=sourceBranch]$sourceBranch"
+    displayName: "Get correct artifact downloading branch"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
       pipeline: Azure.sonic-buildimage.common_libs
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(sourceBranch)'
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib.armhf
       patterns: |
@@ -261,7 +285,7 @@ jobs:
       pipeline: 9
       artifact: sonic-swss-common.armhf
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(sourceBranch)'
       path: '$(Build.SourcesDirectory)/sonic-swss-common.armhf'
     displayName: "Download sonic swss common deb packages"
   - script: |

--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -48,7 +48,7 @@ std::vector<std::string> DbInterface::mMuxState = {"active", "standby", "unknown
 std::vector<std::string> DbInterface::mMuxLinkmgrState = {"uninitialized", "unhealthy", "healthy"};
 std::vector<std::string> DbInterface::mMuxMetrics = {"start", "end"};
 std::vector<std::string> DbInterface::mLinkProbeMetrics = {"link_prober_unknown_start", "link_prober_unknown_end", "link_prober_wait_start", "link_prober_active_start", "link_prober_standby_start"};
-std::vector<std::string> DbInterface::mActiveStandbySwitchCause = {"Peer_Heartbeat_Missing" , "Peer_Link_Down" , "Tlv_Switch_Active_Command" , "Link_Down" , "Transceiver_Daemon_Timeout" , "Matching_Hardware_State" , "Config_Mux_Mode"};
+std::vector<std::string> DbInterface::mActiveStandbySwitchCause = {"Peer_Heartbeat_Missing" , "Peer_Link_Down" , "Tlv_Switch_Active_Command" , "Link_Down" , "Transceiver_Daemon_Timeout" , "Matching_Hardware_State" , "Config_Mux_Mode", "Hardware_State_Unknown"};
 
 //
 // ---> DbInterface(mux::MuxManager *muxManager);
@@ -201,7 +201,7 @@ void DbInterface::handlePostSwitchCause(
         boost::posix_time::ptime time
 )
 {
-    MUXLOGDEBUG(boost::format("%s: post switch cause %s") %
+    MUXLOGWARNING(boost::format("%s: post last switch cause %s") %
         portName %
         mActiveStandbySwitchCause[static_cast<int>(cause)]
     );

--- a/src/link_manager/LinkManagerStateMachine.h
+++ b/src/link_manager/LinkManagerStateMachine.h
@@ -152,6 +152,7 @@ public:
         TransceiverDaemonTimeout,
         MatchingHardwareState,
         ConfigMuxMode,
+        HarewareStateUnknown,
 
         Count
     };
@@ -1063,6 +1064,8 @@ private:
     boost::function<void ()> mRevertIntervalFnPtr;
 
     uint32_t mWaitActiveUpCount = 0;
+    uint32_t mActiveUnknownUpCount = 0;
+    uint32_t mStandbyUnknownUpCount = 0;
     uint32_t mMuxUnknownBackoffFactor = 1;
     uint32_t mWaitStandbyUpBackoffFactor = 1;
     uint32_t mUnknownActiveUpBackoffFactor = 1;

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1281,4 +1281,44 @@ TEST_F(LinkManagerStateMachineTest, EnableDecreaseLinkProberIntervalFeature)
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mDecreaseIntervalCallCount, 1);
 }
 
+TEST_F(LinkManagerStateMachineTest, CableFirmwareFailure)
+{
+    // This test case is for scenario when we have a bad mux firmware.
+    // Issue: If a switchover triggered in this case, tunnel route will be added/removed
+    // unexpectedly, and cause traffic drop. 
+    // Expected behavior: linkmgrd should enforce another toggle. 
+
+    setMuxStandby();
+
+    postMuxEvent(mux_state::MuxState::Unknown, 3);
+    VALIDATE_STATE(Standby, Wait, Up);
+
+    handleProbeMuxState("unknown", 4);
+    VALIDATE_STATE(Standby, Wait, Up);
+
+    handleProbeMuxState("unknown", 4);
+    VALIDATE_STATE(Standby, Wait, Up);
+
+    runIoService(2);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 1);
+    EXPECT_EQ(mDbInterfacePtr->mLastPostedSwitchCause, link_manager::LinkManagerStateMachine::SwitchCause::HarewareStateUnknown);
+
+    // if link prober state changes
+    postLinkProberEvent(link_prober::LinkProberState::Active);
+    VALIDATE_STATE(Active, Wait, Up);
+
+    postMuxEvent(mux_state::MuxState::Unknown, 3);
+    VALIDATE_STATE(Active, Wait, Up);
+
+    handleProbeMuxState("unknown", 4);
+    VALIDATE_STATE(Active, Wait, Up);
+
+    handleProbeMuxState("unknown", 4);
+    VALIDATE_STATE(Active, Wait, Up);
+
+    runIoService(2);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastPostedSwitchCause, link_manager::LinkManagerStateMachine::SwitchCause::HarewareStateUnknown);
+}
+
 } /* namespace test */


### PR DESCRIPTION
Cherry-pick conflict for #184.

Summary:
Fixes # (issue)

Fixing a common issue in production. Root cause is bad firmware failing to respond to mux toggle or mux query.

For example, in below senario, we will have two `standby` ToRs in the end, both sides will have tunnel-route installed.
```
UT0: active -> toggle standby -> toggles succeeds -> healthy
LT0: standby > receive heartbeat event active due to peer's toggle -> probe mux state -> mux state unknown -> probe mux state -> repeating ...
```
The traffic loss in this scenario is evitable, as heartbeat behavior is very consistent and from that linkmgrd should be table to tell the current mux direction.

The solution is when mux probing is the **ONLY** failing component, linkmgrd enforce a switchover based on heartbeat status. To ensure the heartbeat behaviour is consistent, we count how many times we enter the composite state **continuously**.

sign-off: Jing Zhang zhangjing@microsoft.com
