### PR TITLE
Enable debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ JOBS := $(subst -j,,$(JOB_FLAG))
 
 # keep debug option only
 CPP_FLAGS := $(if $(findstring -g,$(CXXFLAGS)), -g)
-LD_FLAGS := $(if $(findstring -g,$(CXXFLAGS)), -g)
 
 release-targets: CPP_FLAGS := $(CPP_FLAGS) -O3 -Wall -c -fmessage-length=0 -fPIC -flto
 test-targets: CPP_FLAGS := $(CPP_FLAGS) -O0 -Wall -c -fmessage-length=0 -fPIC $(GCOV_FLAGS)
@@ -70,7 +69,7 @@ all: sonic-linkmgrd
 release-targets: $(OBJS) $(USER_OBJS) $(OBJS_LINKMGRD)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C++ Linker'
-	$(CXX) -pthread -o "$(LINKMGRD_TARGET)" $(OBJS) $(OBJS_LINKMGRD) $(USER_OBJS) $(LIBS) $(LD_FLAGS)
+	$(CXX) -pthread -o "$(LINKMGRD_TARGET)" $(OBJS) $(OBJS_LINKMGRD) $(USER_OBJS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 
@@ -81,7 +80,7 @@ sonic-linkmgrd: clean-targets
 test-targets: $(OBJS) $(USER_OBJS) $(OBJS_LINKMGRD_TEST)
 	@echo 'Building target: $@'
 	@echo 'Invoking: GCC C++ Linker'
-	$(CXX) -pthread -fprofile-generate -lgcov -o "$(LINKMGRD_TEST_TARGET)" $(OBJS) $(OBJS_LINKMGRD_TEST) $(USER_OBJS) $(LIBS) $(LIBS_TEST) $(LD_FLAGS)
+	$(CXX) -pthread -fprofile-generate -lgcov -o "$(LINKMGRD_TEST_TARGET)" $(OBJS) $(OBJS_LINKMGRD_TEST) $(USER_OBJS) $(LIBS) $(LIBS_TEST)
 	@echo 'Executing test target: $@'
 	LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.5 ./$(LINKMGRD_TEST_TARGET)
 	$(GCOVR) -r ./ --html --html-details -o $(LINKMGRD_TEST_TARGET)-result.html


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #196 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Enable `docker-mux-dbg` to have correct debug symbol files.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
As Debian passes debug options via environment variable `CXXFLAGS` or `CFLAGS` during package build, so let's add `-g` to the `CPP_FLAGS` if `CXXFLAGS` contains `-g`. So the final `linkmgrd` binary could have debug symbols.

#### How did you verify/test it?
use `sonic-buildimage` to build target `target/debs/bullseye/sonic-linkmgrd-dbgsym_1.0.0-1_amd64.deb`, and verify the symbol files:
```
$ ls -lah usr/lib/debug/.build-id/48/619bee180a75bafa2b1ee64a5a26c8c00ad0fe.debug
-rw-r--r-- 1 lolv lolv 11M Oct 26  2020 usr/lib/debug/.build-id/48/619bee180a75bafa2b1ee64a5a26c8c00ad0fe.debug
$ ls -lah usr/sbin/linkmgrd
-rwxr-xr-x 1 lolv lolv 998K Oct 26  2020 usr/sbin/linkmgrd
```
```
(gdb) exec-file usr/sbin/linkmgrd
(gdb) symbol-file usr/lib/debug/.build-id/7a/19e9cd44f81ddb0bbc3eab757319675ae606de.debug
Reading symbols from usr/lib/debug/.build-id/7a/19e9cd44f81ddb0bbc3eab757319675ae606de.debug...
(gdb) list main
warning: Source file is more recent than executable.
65
66          //
67          // Constants for command line argument strings:
68          //
69          boost::log::trivial::severity_level level;
70          bool extraLogFile = false;
71          bool measureSwitchover = false;
72          bool defaultRoute = false;
73
74          program_options::options_description description("linkmgrd options");
quit)
```

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->