### PR TITLE
[active-standby][bsl] fix no mux probe issue

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -724,8 +724,6 @@ private:
     boost::function<void ()> mResetIcmpPacketCountsFnPtr;
     boost::function<void ()> mSendPeerProbeCommandFnPtr;
 
-    DefaultRoute mDefaultRouteState = DefaultRoute::Wait;
-
     bool mContinuousLinkProberUnknownEvent = false;
 };
 

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -1137,8 +1137,10 @@ void ActiveStandbyStateMachine::LinkProberUnknownMuxStandbyLinkUpTransitionFunct
     // Start switching MUX to active state as we lost HB from active ToR
     if (mDefaultRouteState == DefaultRoute::OK) {
         switchMuxState(link_manager::ActiveStandbyStateMachine::SwitchCause::PeerHeartbeatMissing, nextState, mux_state::MuxState::Label::Active);
+        mDeadlineTimer.cancel();
+    } else {
+        enterMuxWaitState(mCompositeState);
     }
-    mDeadlineTimer.cancel();
     mWaitActiveUpCount = 0;
 }
 

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -1139,7 +1139,7 @@ void ActiveStandbyStateMachine::LinkProberUnknownMuxStandbyLinkUpTransitionFunct
         switchMuxState(link_manager::ActiveStandbyStateMachine::SwitchCause::PeerHeartbeatMissing, nextState, mux_state::MuxState::Label::Active);
         mDeadlineTimer.cancel();
     } else {
-        enterMuxWaitState(mCompositeState);
+        enterMuxWaitState(nextState);
     }
     mWaitActiveUpCount = 0;
 }

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -847,8 +847,6 @@ private:
 
     bool mContinuousLinkProberUnknownEvent = false; // When posting unknown_end event, we want to make sure the previous state is unknown.
 
-    DefaultRoute mDefaultRouteState = DefaultRoute::Wait;
-
     link_manager::ActiveStandbyStateMachine::SwitchCause mSendSwitchActiveCommandCause;
 };
 

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -533,6 +533,15 @@ public:
     */
     link_state::LinkStateMachine& getLinkStateMachine() {return mLinkStateMachine;};
 
+    /**
+    *@method getDefaultRouteState
+    *
+    *@brief getter for default route state, for testing use only
+    *
+    *@return value of current default route state
+    */
+    DefaultRoute getDefaultRouteState() {return mDefaultRouteState;};
+
 private:
     /**
      *@enum anonymous
@@ -633,6 +642,8 @@ private:
     Label mLabel = Label::Uninitialized;
 
     std::bitset<ComponentCount> mComponentInitState = {0};
+
+    DefaultRoute mDefaultRouteState = DefaultRoute::Wait;
 };
 
 } /* namespace link_manager */


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Noticed an issue in BSL scenario that, both ToRs were be in `standby` state after mux service restart or reboot. The issue was due to no mux probe was triggered by linkmgrd. 

Root cause was link manager state machine corner case: 

* State machine activated as standby healthy after reboot or service restart
```
Apr 21 21:24:11.563419 - WARNING mux#linkmgrd: link_manager/LinkManagerStateMachine.cpp:478 activateStateMachine: Ethernet124: (P: Unknown, M: Standby, L: Up) -> (P: Standby, M: Standby, L: Up)
Apr 21 21:24:11.580274 - WARNING mux#linkmgrd: link_manager/LinkManagerStateMachine.cpp:291 setLabel: Ethernet124: Linkmgrd state is: Standby Healthy
```
* There is no heartbeat in L2 mode
```
Apr 21 21:24:11.889344 - WARNING mux#linkmgrd: link_manager/LinkManagerStateMachine.cpp:501 handleStateChange: Ethernet124: Received link prober event, new state: Unknown
Apr 21 21:24:11.889344 - WARNING mux#linkmgrd: DbInterface.cpp:175 postLinkProberMetricsEvent: Ethernet124: posting link prober event link_prober_unknown_start
```
* Switchover was skipped https://github.com/sonic-net/sonic-linkmgrd/blob/01792078de69b3205b870074dac3a9804f3e900e/src/link_manager/LinkManagerStateMachine.cpp#L1229-L1231
```
Apr 21 21:24:11.889344 - WARNING mux#linkmgrd: link_manager/LinkManagerStateMachine.cpp:525 handleStateChange: Ethernet124: (P: Standby, M: Standby, L: Up) -> (P: Wait, M: Standby, L: Up)
Apr 21 21:24:11.889344 - WARNING mux#linkmgrd: DbInterface.cpp:392 handlePostLinkProberMetrics: Ethernet124: posting link prober event link_prober_unknown_start
```
* No further toggle or mux probe is triggered. State machine is stuck. 
 
sign-off: Jing Zhang zhangjing@microsoft.com
### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To unblock vendor side BSL tests. (A workaround to disable default route feature has been shared, this PR is a long-term fix.)

#### How did you do it?
Do mux probe when skipping toggle. 

#### How did you verify/test it?
* Followed the step to repro, with this change, issue can't be reproduced. 
* Trigger mux state change on peer side, local state will be able to sync up eventually. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->