### PR TITLE
Re-handle pre-init mux config notification after state machine init

### DIFF
--- a/src/common/AsyncEvent.h
+++ b/src/common/AsyncEvent.h
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2021 (c) Microsoft Corporation.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * AsyncEvent.h
+ *
+ *  Created on: April 24, 2023
+ *      Author: Longxiang Lyu
+ */
+
+#ifndef ASYNCEVENT_H
+#define ASYNCEVENT_H
+
+#include <boost/asio.hpp>
+#include <boost/bind/bind.hpp>
+#include <boost/function.hpp>
+
+namespace common
+{
+
+/**
+ * @class AsyncEvent
+ * 
+ * @brief an asynchronous event implemented with boost::asio::deadline_timer
+ */
+class AsyncEvent
+{
+public:
+    /**
+     *@method AsyncEvent
+     * 
+     *@brief Construct a new AsyncEvent object
+     *
+     *@param strand                 a boost strand object
+     */
+    AsyncEvent(boost::asio::io_service::strand& strand)
+        : mStrand(strand), mWaitSetTimer(strand.context(), boost::posix_time::ptime(boost::posix_time::pos_infin))
+    {}
+
+    /**
+    *@method AsyncEvent
+    *
+    *@brief class copy constructor
+    */
+    AsyncEvent(const AsyncEvent&) = delete;
+
+    /**
+     *@method ~AsyncEvent 
+     *
+     *@brief Destroy the Async Event object
+     */
+    virtual ~AsyncEvent() = default;
+
+    /**
+     *@method registerWaitHandler
+     *
+     *@brief register a wait handlers to be called when event is notified
+     *
+     *@param handler                a wait handler for the event
+     */
+    template <typename WaitHandler>
+    void registerWaitHandler(WaitHandler&& handler)
+    {
+        mWaitSetTimer.async_wait(
+            boost::asio::bind_executor(
+                mStrand,
+                [handler = std::move(handler)](const boost::system::error_code& errorCode) {
+                    if (errorCode != boost::asio::error::operation_aborted) {
+                        handler();
+                    }
+                }));
+    }
+
+    /**
+     *@method notify
+     *
+     *@brief notify one registered wait handlers to execute
+     */
+    void notify() { mWaitSetTimer.cancel_one(); }
+
+    /**
+     *@method notify_all
+     *
+     *@brief notify all registered wait handlers to execute
+     */
+    void notify_all() { mWaitSetTimer.cancel(); }
+
+private:
+    boost::asio::io_service::strand mStrand;
+    boost::asio::deadline_timer mWaitSetTimer;
+};
+
+} /* namespace common */
+
+#endif /* ASYNCEVENT_H */

--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -51,7 +51,8 @@ ActiveActiveStateMachine::ActiveActiveStateMachine(
       mDeadlineTimer(strand.context()),
       mWaitTimer(strand.context()),
       mPeerWaitTimer(strand.context()),
-      mResyncTimer(strand.context())
+      mResyncTimer(strand.context()),
+      mWaitStateMachineInit(strand)
 {
     assert(muxPortPtr != nullptr);
     mMuxPortPtr->setMuxLinkmgrState(mLabel);
@@ -96,6 +97,8 @@ void ActiveActiveStateMachine::activateStateMachine()
         updateMuxLinkmgrState();
 
         startAdminForwardingStateSyncUpTimer();
+
+        mWaitStateMachineInit.notify_all();
     }
 }
 
@@ -257,6 +260,10 @@ void ActiveActiveStateMachine::handleMuxConfigNotification(const common::MuxPort
         LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
         mCompositeState = nextState;
         updateMuxLinkmgrState();
+    } else {
+        mWaitStateMachineInit.registerWaitHandler(
+            boost::bind(&ActiveActiveStateMachine::handleMuxConfigNotification, this, mode)
+        );
     }
     shutdownOrRestartLinkProberOnDefaultRoute();
 }

--- a/src/link_manager/LinkManagerStateMachineActiveActive.h
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.h
@@ -24,6 +24,7 @@
 #include <vector>
 #include <boost/function.hpp>
 
+#include "common/AsyncEvent.h"
 #include "link_manager/LinkManagerStateMachineBase.h"
 #include "link_prober/LinkProber.h"
 #include "link_prober/LinkProberState.h"
@@ -713,6 +714,8 @@ private:
     boost::asio::deadline_timer mWaitTimer;
     boost::asio::deadline_timer mPeerWaitTimer;
     boost::asio::deadline_timer mResyncTimer;
+
+    common::AsyncEvent mWaitStateMachineInit;
 
     boost::function<void()> mInitializeProberFnPtr;
     boost::function<void()> mStartProbingFnPtr;

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -149,6 +149,10 @@ void FakeMuxPort::activateStateMachine()
     if (mMuxPortConfig.ifEnableDefaultRouteFeature() == true){
         mFakeLinkProber->shutdownTxProbes();
     }
+
+    if (mMuxPortConfig.getPortCableType() == common::MuxPortConfig::PortCableType::ActiveActive) {
+        getActiveActiveStateMachinePtr()->mWaitStateMachineInit.notify_all();
+    }
 }
 
 } /* namespace test */

--- a/test/LinkManagerStateMachineActiveActiveTest.h
+++ b/test/LinkManagerStateMachineActiveActiveTest.h
@@ -36,13 +36,13 @@ public:
     void postLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count = 0);
     void postPeerLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count = 0);
     void postMuxEvent(mux_state::MuxState::Label label, uint32_t count = 0);
-    void postLinkEvent(link_state::LinkState::Label label, uint32_t count = 0);
+    void postLinkEvent(link_state::LinkState::Label label, uint32_t count = 0, bool poll = false);
     void postSuspendTimerExpiredEvent(uint32_t count = 0);
-    void handleMuxState(std::string, uint32_t count = 0);
+    void handleMuxState(std::string, uint32_t count = 0, bool poll = false);
     void handlePeerMuxState(std::string, uint32_t count = 0);
     void handleProbeMuxState(std::string, uint32_t count = 0);
     void handleLinkState(std::string linkState, uint32_t count = 0);
-    void handleMuxConfig(std::string config, uint32_t count = 0);
+    void handleMuxConfig(std::string config, uint32_t count = 0, bool poll = false);
     void activateStateMachine(bool enable_feature_default_route=false);
     void setMuxActive();
     void setMuxStandby();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test




### Approach
#### What is the motivation for this PR?
During a config reload, mux config notification is always received before state machine init, and the state machine will not do a toggle based on the mux config after state machine init. Let's enable the state machine to re-handle the mux config notification after the state machine init and do a toggle based on the mux config.

MSFT:ADO: 17708339

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
1. Add a class `AsyncEvent` that could act as an event that could execute registered callbacks if the event is notified.
2.  Define `ActiveActiveStateMachine::mWaitStateMachineInit`(of `AsyncEvent`) as a wait event to register any mux config notification received before state machine init.
3. Notify the wait event `ActiveActiveStateMachine::mWaitStateMachineInit` when activating state machine, so the mux config will be handled.

#### How did you verify/test it?
UT

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->