### PR TITLE
[codeql] remove hard coded line numbers in `sed` commands

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -87,9 +87,9 @@ jobs:
     - name: build
       run: |
         set -x
-        sed -i '19 i JOBS := 1' Makefile
+        sed -i "/JOBS := \$(subst -j,,\$(JOB_FLAG))/a JOBS := 1" Makefile
         sed -i -e "s/ -flto//g" Makefile
-        sed -i "37 i LIBS += -L$(dirname $GITHUB_WORKSPACE)/usr/lib/x86_64-linux-gnu -I$(dirname $GITHUB_WORKSPACE)/usr/include" Makefile
+        sed -i "/-include objects.mk/a LIBS += -L\$(dirname \$GITHUB_WORKSPACE)/usr/lib/x86_64-linux-gnu -I\$(dirname \$GITHUB_WORKSPACE)/usr/include" Makefile 
         make all INCLUDES="-L$(dirname $GITHUB_WORKSPACE)/usr/lib/x86_64-linux-gnu -I$(dirname $GITHUB_WORKSPACE)/usr/include"
 
     - name: Perform CodeQL Analysis


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to fix CodeQL failures. The issue was due to hard coded line numbers in `sed` commands. The `sed` commands were used to update `Makefile`, and `Makefile` has been changed recently, causing the line numbers to be off. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To unblock PR merging. 

#### How did you do it?
Use `/a` to append new lines. 

#### How did you verify/test it?
Tested with the new `sed` commands, lines were added as expected. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->