### PR TITLE
[link prober] Increase pause/restart probe log verbosity

### DIFF
--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -865,14 +865,14 @@ void LinkProber::resetIcmpPacketCounts()
 
 void LinkProber::shutdownTxProbes()
 {
-    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+    MUXLOGWARNING(boost::format("%s: shutdown probe") % mMuxPortConfig.getPortName());
 
     mShutdownTx = true;
 }
 
 void LinkProber::restartTxProbes()
 {
-    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+    MUXLOGWARNING(boost::format("%s: restart probe") % mMuxPortConfig.getPortName());
 
     mShutdownTx = false;
 }

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -188,7 +188,7 @@ void LinkProber::startProbing()
 //
 void LinkProber::suspendTxProbes(uint32_t suspendTime_msec)
 {
-    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+    MUXLOGWARNING(boost::format("%s: suspend ICMP heartbeat probing") % mMuxPortConfig.getPortName());
 
     mSuspendTimer.expires_from_now(boost::posix_time::milliseconds(suspendTime_msec));
     mSuspendTimer.async_wait(mStrand.wrap(boost::bind(
@@ -207,7 +207,7 @@ void LinkProber::suspendTxProbes(uint32_t suspendTime_msec)
 //
 void LinkProber::resumeTxProbes()
 {
-    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+    MUXLOGWARNING(boost::format("%s: resume ICMP heartbeat probing") % mMuxPortConfig.getPortName());
 
     mSuspendTimer.cancel();
 }
@@ -520,7 +520,7 @@ void LinkProber::handleTimeout(boost::system::error_code errorCode)
 //
 void LinkProber::handleSuspendTimeout(boost::system::error_code errorCode)
 {
-    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+    MUXLOGWARNING(boost::format("%s: suspend timeout, resume ICMP heartbeat probing") % mMuxPortConfig.getPortName());
 
     mSuspendTx = false;
 
@@ -865,14 +865,14 @@ void LinkProber::resetIcmpPacketCounts()
 
 void LinkProber::shutdownTxProbes()
 {
-    MUXLOGWARNING(boost::format("%s: shutdown probe") % mMuxPortConfig.getPortName());
+    MUXLOGWARNING(boost::format("%s: shutdown ICMP heartbeat probing") % mMuxPortConfig.getPortName());
 
     mShutdownTx = true;
 }
 
 void LinkProber::restartTxProbes()
 {
-    MUXLOGWARNING(boost::format("%s: restart probe") % mMuxPortConfig.getPortName());
+    MUXLOGWARNING(boost::format("%s: restart ICMP heartbeat probing") % mMuxPortConfig.getPortName());
 
     mShutdownTx = false;
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
As the subject.
Work item tracking
Microsoft ADO (number only): 24609952

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

#### How did you do it?
Increase log level to warning so probe pause/restart could be observed in syslog.

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->