### PR TITLE
[active-standby] Fix extra toggle observed in `config reload`

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -247,8 +247,7 @@ void ActiveStandbyStateMachine::enterLinkProberState(CompositeState &nextState, 
 
     if (forceReset && ps(nextState) == label) {
         // only need to reset the link prober state if the state remains the same
-        link_prober::LinkProberState *currentLinkProberState = dynamic_cast<link_prober::LinkProberState *> (mLinkProberStateMachinePtr->getCurrentState());
-        currentLinkProberState->resetState();
+        mLinkProberStateMachinePtr->resetCurrentState();
     }
 
     ps(nextState) = label;

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -557,7 +557,7 @@ void ActiveStandbyStateMachine::handleStateChange(LinkStateEvent &event, link_st
             // start fresh when the link transition from Down to UP state
             // and so the link prober will initially match the MUX state
             // There is a problem with this approach as it will hide link flaps that result in lost heart-beats.
-            initLinkProberState(nextState);
+            initLinkProberState(nextState, true);
 //            enterMuxWaitState(nextState);
         } else if (ls(mCompositeState) == link_state::LinkState::Up &&
                    ls(nextState) == link_state::LinkState::Down &&

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -143,9 +143,11 @@ private:
     *                               entry will be changed to align with state label provided
     *@param label (in)              state to switch to
     *
+    *@param forceReset (in)         force reset the aligned link prober state
+    *
     *@return none
     */
-    inline void enterLinkProberState(CompositeState &nextState, link_prober::LinkProberState::Label label);
+    inline void enterLinkProberState(CompositeState &nextState, link_prober::LinkProberState::Label label, bool forceReset=false);
 
     /**
     *@method enterMuxState
@@ -460,9 +462,11 @@ private:
     *@param compositeState (in, out)    reference to composite state, the state linkProber
     *                                   entry will be changed to align with MuxState
     *
+    *@param forceReset (in)             force reset the aligned link prober state
+    *
     *@return none
     */
-    void initLinkProberState(CompositeState &compositeState);
+    void initLinkProberState(CompositeState &compositeState, bool forceReset=false);
 
     /**
     *@method LinkProberStandbyMuxActiveLinkUpTransitionFunction

--- a/src/link_prober/LinkProberStateMachineBase.cpp
+++ b/src/link_prober/LinkProberStateMachineBase.cpp
@@ -55,6 +55,17 @@ LinkProberStateMachineBase::LinkProberStateMachineBase(
 }
 
 //
+// ---> LinkProberStateMachineBase::resetCurrentState();
+//
+// reset current link prober state
+//
+void LinkProberStateMachineBase::resetCurrentState()
+{
+    LinkProberState *currentLinkProberState = dynamic_cast<LinkProberState *> (getCurrentState());
+    currentLinkProberState->resetState();
+}
+
+//
 // ---> LinkProberStateMachineBase::postLinkProberStateEvent(E &e);
 //
 // post LinkProberState event to the state machine

--- a/src/link_prober/LinkProberStateMachineBase.h
+++ b/src/link_prober/LinkProberStateMachineBase.h
@@ -401,6 +401,14 @@ public:
 
 public:
     /**
+     *@method resetCurrentState
+     *
+     *@brief reset current link prober state
+     */
+    void resetCurrentState();
+
+public:
+    /**
      *@method getIcmpSelfEvent
      *
      *@brief getter for IcmpSelfEvent object

--- a/test/LinkManagerStateMachineTest.h
+++ b/test/LinkManagerStateMachineTest.h
@@ -39,7 +39,7 @@ public:
     virtual ~LinkManagerStateMachineTest() = default;
 
     void runIoService(uint32_t count = 0);
-    void postLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count = 0);
+    void postLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count = 0, uint32_t detect_multiplier = 0);
     void postMuxEvent(mux_state::MuxState::Label label, uint32_t count = 0);
     void postLinkEvent(link_state::LinkState::Label label, uint32_t count = 0);
     void postSuspendTimerExpiredEvent(uint32_t count = 0);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #217

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Fix the issue that an extra mux toggle is observed when the standby ToR does a config reload.
Two reasons:
1. extra toggle due to link prober init to `unknown` when the mux is `wait`
The state transitions are:
(`unknown`, `standby`, `down`) --  activate state machine -->
(`standby`, `standby`, `down`) --> link prober `unknown` -->
(`unknown`, `standby`, `down`) --> enter mux `wait` and probe mux -->
(`unknown`, `wait`, `down`) --> port `up` -->
(`unknown`, `wait`, `up`) --> mux probe `standby` -->
(`unknown`, `standby`, `up`) --> **toggle to active** 

2. extra toggle due to the port `up` event arriving within the link prober `unknown` detection period


Signed-off-by: Longxiang Lyu <lolv@microsoft.com>


##### Work item tracking
- Microsoft ADO **(number only)**:  24794476

#### How did you do it?
1. when the port `up` and init the link prober state, init the link prober state to `wait` when the mux state is `wait`
2. reset the link prober state when port `up` to refresh the detection.

#### How did you verify/test it?
UT

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->