### PR TITLE
[warmboot] config all interfaces back to `auto` if reconciliation times out 

### DIFF
--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -570,11 +570,8 @@ void MuxManager::handleWarmRestartReconciliationTimeout(const boost::system::err
         MUXLOGWARNING("Reconciliation timed out after warm restart, set service to reconciled now.");
     }
 
-    uint32_t rc = system("sudo config muxcable mode auto all"); // rc > 0 means success
-
-    if (rc <= 0) {
-        MUXLOGWARNING(boost::format("config mux mode back to auto failed with return code %d") % rc);
-    }
+    int rc = system("sudo config muxcable mode auto all");
+    MUXLOGWARNING(boost::format("config mux mode back to auto completed with return code %d") % rc);
 
     mDbInterfacePtr->setWarmStartStateReconciled();
 }

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -571,7 +571,10 @@ void MuxManager::handleWarmRestartReconciliationTimeout(const boost::system::err
     }
 
     uint32_t rc = system("sudo config muxcable mode auto all"); // rc > 0 means success
-    MUXLOGDEBUG(boost::format("config mux mode back to auto completed with return code %d") % rc);
+
+    if (rc <= 0) {
+        MUXLOGWARNING(boost::format("config mux mode back to auto failed with return code %d") % rc);
+    }
 
     mDbInterfacePtr->setWarmStartStateReconciled();
 }

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -570,6 +570,9 @@ void MuxManager::handleWarmRestartReconciliationTimeout(const boost::system::err
         MUXLOGWARNING("Reconciliation timed out after warm restart, set service to reconciled now.");
     }
 
+    uint32_t rc = system("sudo config muxcable mode auto all"); // rc > 0 means success
+    MUXLOGDEBUG(boost::format("config mux mode back to auto completed with return code %d") % rc);
+
     mDbInterfacePtr->setWarmStartStateReconciled();
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to fix a warmboot bug that when linkmgrd reconciliation times out, some interfaces are left in `manual` mode. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To make sure all interfaces have correct muxcable config. 

##### Work item tracking
- Microsoft ADO **(number only)**:
24911432

#### How did you do it?
Run cli when timeout handler is called. 

#### How did you verify/test it?
1. Ran warmboot with healthy dualtor DUT.
2. Ran warmboot with unhealthy dualtor DUT. 

Both cases passed. 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->