### PR TITLE
[active-standby] Add oscillation logic when there is no heartbeat on both sides

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -47,7 +47,7 @@ std::vector<std::string> DbInterface::mMuxState = {"active", "standby", "unknown
 std::vector<std::string> DbInterface::mMuxLinkmgrState = {"uninitialized", "unhealthy", "healthy"};
 std::vector<std::string> DbInterface::mMuxMetrics = {"start", "end"};
 std::vector<std::string> DbInterface::mLinkProbeMetrics = {"link_prober_unknown_start", "link_prober_unknown_end", "link_prober_wait_start", "link_prober_active_start", "link_prober_standby_start"};
-std::vector<std::string> DbInterface::mActiveStandbySwitchCause = {"Peer_Heartbeat_Missing" , "Peer_Link_Down" , "Tlv_Switch_Active_Command" , "Link_Down" , "Transceiver_Daemon_Timeout" , "Matching_Hardware_State" , "Config_Mux_Mode", "Hardware_State_Unknown"};
+std::vector<std::string> DbInterface::mActiveStandbySwitchCause = {"Peer_Heartbeat_Missing" , "Peer_Link_Down" , "Tlv_Switch_Active_Command" , "Link_Down" , "Transceiver_Daemon_Timeout" , "Matching_Hardware_State" , "Config_Mux_Mode", "Hardware_State_Unknown", "Timed_Oscillation"};
 
 //
 // ---> DbInterface(mux::MuxManager *muxManager);

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -415,7 +415,7 @@ public:
 
 private:
     uint8_t mNumberOfThreads = 5;
-    uint32_t mOscillationTimeout_sec = 60;
+    uint32_t mOscillationTimeout_sec = 600;
     uint32_t mTimeoutIpv4_msec = 100;
     uint32_t mTimeoutIpv6_msec = 1000;
     uint32_t mPositiveStateChangeRetryCount = 1;

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -275,6 +275,15 @@ public:
     inline uint32_t getSuspendTimeout_msec() const {return (mNegativeStateChangeRetryCount + 1) * mTimeoutIpv4_msec;};
 
     /**
+    *@method getOscillationInterval_sec
+    *
+    *@brief getter for mux state oscillation interval
+    *
+    *@return oscillation interval
+    */
+    inline uint32_t getOscillationInterval_sec() const {return mOscillationTimeout_sec;};
+
+    /**
     *@method getMuxStateChangeRetryCount
     *
     *@brief getter for MuxState state change retry count
@@ -406,8 +415,10 @@ public:
 
 private:
     uint8_t mNumberOfThreads = 5;
+    uint32_t mOscillationTimeout_sec = 300;
     uint32_t mTimeoutIpv4_msec = 100;
     uint32_t mTimeoutIpv6_msec = 1000;
+    uint32_t mOscillationTimeout_sec = 300;
     uint32_t mPositiveStateChangeRetryCount = 1;
     uint32_t mNegativeStateChangeRetryCount = 3;
     uint32_t mLinkProberStatUpdateIntervalCount = 300; 

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -415,7 +415,7 @@ public:
 
 private:
     uint8_t mNumberOfThreads = 5;
-    uint32_t mOscillationTimeout_sec = 600;
+    uint32_t mOscillationTimeout_sec = 300;
     uint32_t mTimeoutIpv4_msec = 100;
     uint32_t mTimeoutIpv6_msec = 1000;
     uint32_t mPositiveStateChangeRetryCount = 1;

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -415,10 +415,9 @@ public:
 
 private:
     uint8_t mNumberOfThreads = 5;
-    uint32_t mOscillationTimeout_sec = 300;
+    uint32_t mOscillationTimeout_sec = 60;
     uint32_t mTimeoutIpv4_msec = 100;
     uint32_t mTimeoutIpv6_msec = 1000;
-    uint32_t mOscillationTimeout_sec = 300;
     uint32_t mPositiveStateChangeRetryCount = 1;
     uint32_t mNegativeStateChangeRetryCount = 3;
     uint32_t mLinkProberStatUpdateIntervalCount = 300; 

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -284,6 +284,18 @@ public:
     inline uint32_t getOscillationInterval_sec() const {return mOscillationTimeout_sec;};
 
     /**
+    *@method setOscillationInterval_sec
+    *
+    *@brief setter for mux state oscillation interval
+    *
+    *@param oscillationInterval_sec (in) oscillation interval
+    *
+    *@return none
+    */
+    inline void setOscillationInterval_sec(uint32_t oscillationInterval_sec) {mOscillationTimeout_sec = oscillationInterval_sec;};
+
+
+    /**
     *@method getMuxStateChangeRetryCount
     *
     *@brief getter for MuxState state change retry count

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -289,11 +289,17 @@ public:
     *@brief setter for mux state oscillation interval
     *
     *@param oscillationInterval_sec (in) oscillation interval
+    *@param force (in) force set the oscillation interval
     *
     *@return none
     */
-    inline void setOscillationInterval_sec(uint32_t oscillationInterval_sec) {mOscillationTimeout_sec = oscillationInterval_sec;};
-
+    inline void setOscillationInterval_sec(uint32_t oscillationInterval_sec, bool force=false) {
+        if (force || oscillationInterval_sec > 300) {
+            mOscillationTimeout_sec = oscillationInterval_sec;
+        } else {
+            mOscillationTimeout_sec = 300;
+        }
+    };
 
     /**
     *@method getMuxStateChangeRetryCount

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -193,6 +193,15 @@ public:
     inline uint32_t getLinkWaitTimeout_msec() const {return mMuxConfig.getSuspendTimeout_msec();};
 
     /**
+    *@method getOscillationInterval_sec
+    *
+    *@brief getter for mux state oscillation interval
+    *
+    *@return oscillation interval
+    */
+    inline uint32_t getOscillationInterval_sec() const {return mMuxConfig.getOscillationInterval_sec();};
+
+    /**
     *@method getMuxStateChangeRetryCount
     *
     *@brief getter for MuxState state change retry count

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -54,7 +54,8 @@ ActiveStandbyStateMachine::ActiveStandbyStateMachine(
         {link_prober::LinkProberState::Label::Unknown, mux_state::MuxState::Label::Wait, link_state::LinkState::Label::Down}
     ),
     mDeadlineTimer(strand.context()),
-    mWaitTimer(strand.context())
+    mWaitTimer(strand.context()),
+    mOscillationTimer(strand.context())
 {
     assert(muxPortPtr != nullptr);
     mMuxStateMachine.setWaitStateCause(mux_state::WaitState::WaitStateCause::SwssUpdate);

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -1038,6 +1038,41 @@ void ActiveStandbyStateMachine::handleMuxWaitTimeout(boost::system::error_code e
 }
 
 //
+// ---> startOscillationTimer();
+//
+// when there is no icmp heartbeat, start a timer to oscillate between active and standby
+//
+void ActiveStandbyStateMachine::startOscillationTimer()
+{
+    // Note: This timer is started when Mux state is active and link prober is in wait state.
+    mOscillationTimer.expires_from_now(boost::posix_time::sec(
+        mMuxPortConfig.getOscillationInterval_sec()
+    ));
+    mOscillationTimer.async_wait(boost::asio::bind_executor(getStrand(), boost::bind(
+            &ActiveStandbyStateMachine::handleOscillationTimeout,
+            this,
+            boost::asio::placeholders::error
+    )));
+}
+
+//
+// ---> handleOscillationTimeout(boost::system::error_code errorCode);
+//
+// handle when oscillation timer expires
+//
+void ActiveStandbyStateMachine::handleOscillationTimeout(boost::system::error_code errorCode)
+{
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
+
+    if (errorCode == boost::system::errc::success &&
+        ps(mCompositeState) == link_prober::LinkProberState::Label::Wait &&
+        ms(mCompositeState) == mux_state::MuxState::Label::Active &&
+        ls(mCompositeState) == link_state::LinkState::Label::Up) {
+            switchMuxState(link_manager::ActiveStandbyStateMachine::SwitchCause::TimedOscillation, mCompositeState, mux_state::MuxState::Label::Standby);
+    }
+}
+
+//
 // ---> initLinkProberState(CompositeState &compositeState, bool forceReset);
 //
 // initialize LinkProberState when configuring the composite state machine
@@ -1262,6 +1297,8 @@ void ActiveStandbyStateMachine::LinkProberWaitMuxActiveLinkUpTransitionFunction(
     if (mWaitActiveUpCount++ & 0x1) {
         mSuspendTxFnPtr(mMuxPortConfig.getLinkWaitTimeout_msec());
     }
+
+    startOscillationTimer();
 }
 
 //

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -1065,7 +1065,7 @@ void ActiveStandbyStateMachine::startOscillationTimer()
 //
 void ActiveStandbyStateMachine::handleOscillationTimeout(boost::system::error_code errorCode)
 {
-    MUXLOGWARNING(mMuxPortConfig.getPortName());
+    MUXLOGDEBUG(mMuxPortConfig.getPortName());
 
     if (errorCode == boost::system::errc::success &&
         ps(mCompositeState) == link_prober::LinkProberState::Label::Wait &&

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -73,6 +73,7 @@ public:
         MatchingHardwareState,
         ConfigMuxMode,
         HarewareStateUnknown,
+        TimedOscillation,
 
         Count
     };
@@ -455,6 +456,26 @@ private:
     void handleMuxWaitTimeout(boost::system::error_code errorCode);
 
     /**
+    *@method startOscillationTimer
+    *
+    *@brief when there is no icmp heartbeat, start a timer to oscillate between active and standby
+    *
+    *@return none
+    */
+    void startOscillationTimer();
+
+    /**
+    *@method handleOscillationTimeout
+    *
+    *@brief handle when oscillation timer expires
+    *
+    *@param errorCode (in)          timer error code
+    *
+    *@return none
+    */
+    void handleOscillationTimeout(boost::system::error_code errorCode);
+
+    /**
     *@method initLinkProberState
     *
     *@brief initialize LinkProberState when configuring the composite state machine
@@ -826,6 +847,7 @@ private:
 
     boost::asio::deadline_timer mDeadlineTimer;
     boost::asio::deadline_timer mWaitTimer;
+    boost::asio::deadline_timer mOscillationTimer;
 
     boost::function<void ()> mInitializeProberFnPtr;
     boost::function<void ()> mStartProbingFnPtr;

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -49,6 +49,7 @@ LinkManagerStateMachineTest::LinkManagerStateMachineTest() :
     mMuxConfig.setPositiveStateChangeRetryCount(mPositiveUpdateCount);
     mMuxConfig.setMuxStateChangeRetryCount(mPositiveUpdateCount);
     mMuxConfig.setLinkStateChangeRetryCount(mPositiveUpdateCount);
+    mMuxConfig.setOscillationInterval_sec(1);
 }
 
 void LinkManagerStateMachineTest::runIoService(uint32_t count)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
This PR is to cover an extreme edge case when none of the dualtors can receive ICMP heartbeat. The goal is to oscillate mux direction between two sides so if one side recovers, mux direction can have a chance to park on this side. 

**Note** that toggles in an unhealthy scenario like this will cause longer disruption than in a healthy scenario. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To avoid mux direction from being parked on one side when missing heartbeat. 

##### Work item tracking
- Microsoft ADO **(number only)**:
25367027

**TODO:** will submit a separate PR for option to disable oscillation or increase interval. 

#### How did you do it?
1. Start a 5-min timer on active side when heartbeat is missing;
2. When timer expires if still missing heartbeat && still active, toggle to standby.

#### How did you verify/test it?
Run the change on lab devices. Oscillation happened like expected (adjusted interval to 1min on lab device): 
```
Nov  7 01:09:43.225217 TOR-B NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:11:59.883266 TOR-B NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:14:49.997030 TOR-B NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:17:45.068746 TOR-B NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:19:57.332493 TOR-B NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:22:14.209417 TOR-B NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:24:30.938922 TOR-B NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:26:47.640098 TOR-B NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:29:04.379680 TOR-B NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:31:13.777881 TOR-B NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation

Nov  7 01:08:41.815651 TOR-A NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:10:59.213299 TOR-A NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:13:16.606989 TOR-A NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:16:12.141991 TOR-A NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:18:53.202499 TOR-A NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:21:09.851763 TOR-A NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:23:26.517250 TOR-A NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:25:43.215731 TOR-A NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:27:59.887524 TOR-A NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
Nov  7 01:30:10.159067 TOR-A NOTICE mux#linkmgrd: DbInterface.cpp:237 handlePostSwitchCause: Ethernet124: post last switch cause Timed_Oscillation
```


#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->