### PR TITLE
[warmboot] use config_db connector to update mux mode config instead of CLI

### DIFF
--- a/src/DbInterface.h
+++ b/src/DbInterface.h
@@ -388,6 +388,15 @@ public:
      */
     virtual void setWarmStartStateReconciled(){swss::WarmStart::setWarmStartState("linkmgrd", swss::WarmStart::RECONCILED);};
 
+    /**
+    *@method getMuxModeConfig
+    *
+    *@brief retrieve mux mode config
+    *
+    *@return port to mux mode map
+    */
+    virtual std::map<std::string, std::string> getMuxModeConfig();
+
 private:
     friend class test::MuxManagerTest;
 

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -570,8 +570,15 @@ void MuxManager::handleWarmRestartReconciliationTimeout(const boost::system::err
         MUXLOGWARNING("Reconciliation timed out after warm restart, set service to reconciled now.");
     }
 
-    int rc = system("sudo config muxcable mode auto all");
-    MUXLOGWARNING(boost::format("config mux mode back to auto completed with return code %d") % rc);
+    std::map<std::string, std::string> muxModeMap = mDbInterfacePtr->getMuxModeConfig();
+    for (auto it = muxModeMap.begin(); it != muxModeMap.end(); ++it) {
+        if (it->second == "auto") {
+            continue;
+        }
+
+        MUXLOGWARNING(boost::format("config mux mode back to auto for %s") % it->first);
+        mDbInterfacePtr->setMuxMode(it->first, "auto");
+    }
 
     mDbInterfacePtr->setWarmStartStateReconciled();
 }

--- a/test/FakeDbInterface.cpp
+++ b/test/FakeDbInterface.cpp
@@ -132,4 +132,13 @@ void FakeDbInterface::postSwitchCause(
     mLastPostedSwitchCause = cause;
 }
 
+std::map<std::string, std::string> FakeDbInterface::getMuxModeConfig()
+{
+    mGetMuxModeConfigInvokeCount++;
+
+    std::map<std::string, std::string> muxModeConfig;
+    muxModeConfig["Ethernet0"] = "manual";
+    return muxModeConfig;
+}
+
 } /* namespace test */

--- a/test/FakeDbInterface.h
+++ b/test/FakeDbInterface.h
@@ -39,6 +39,7 @@ public:
     virtual void handleSetMuxState(const std::string portName, mux_state::MuxState::Label label) override;
     virtual void handleSetPeerMuxState(const std::string portName, mux_state::MuxState::Label label) override;
     virtual void getMuxState(const std::string &portName) override;
+    virtual std::map<std::string, std::string> getMuxModeConfig() override;
     virtual void probeMuxState(const std::string &portName) override;
     virtual void handleProbeForwardingState(const std::string portName) override;
     virtual void setMuxLinkmgrState(
@@ -95,6 +96,7 @@ public:
     uint32_t mSetMuxModeInvokeCount = 0;
     uint32_t mSetWarmStartStateReconciledInvokeCount = 0;
     uint32_t mPostSwitchCauseInvokeCount = 0;
+    uint32_t mGetMuxModeConfigInvokeCount = 0;
 
     link_manager::ActiveStandbyStateMachine::SwitchCause mLastPostedSwitchCause;
     


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to fix `handleWarmRestartReconciliationTimeout`, for failing configuring mux port back to `auto` mode. 

Issue logs: 
```
Dec  3 20:22:23.715483  NOTICE mux#linkmgrd: MuxManager.cpp:570 handleWarmRestartReconciliationTimeout: Reconciliation timed out after warm restart, set service to reconciled now.
Dec  3 20:22:23.717051  NOTICE mux#linkmgrd: MuxManager.cpp:574 handleWarmRestartReconciliationTimeout: config mux mode back to auto completed with return code 32512
Dec  3 20:22:23.717427  INFO mux#supervisord: linkmgrd sh: 1: sudo: not found
Dec  3 20:22:23.717427  NOTICE mux#linkmgrd: :- setWarmStartState: linkmgrd warm start state changed to reconciled
```

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To config mux mode back to `auto` in warm boot reconciliation. 

##### Work item tracking
- Microsoft ADO **(number only)**:
25587937

#### How did you do it?
1. Get `MUX_CABLE|<PORTNAME> entries from CONFIG_DB when reconciliation timed out. 
2. Updated all non-auto mode to auto mode.

#### How did you verify/test it?
1. Unit tests. 
2. Ran warm-reboot on lab devices. 
```
$ sudo zgrep getMuxMode /var/log/syslog
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet28, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet88, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet64, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet16, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet84, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet60, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet36, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet56, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet96, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet72, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet52, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet12, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet40, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet68, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet32, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet76, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet48, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet8, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet20, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet92, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet4, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet44, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet80, mode mux state = manual
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: DbInterface.cpp:896 getMuxModeConfig: port: Ethernet24, mode mux state = manual
admin@:~$ sudo zgrep "config mux mode back to auto for" /var/log/syslog
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet12
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet16
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet20
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet24
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet28
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet32
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet36
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet4
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet40
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet44
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet48
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet52
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet56
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet60
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet64
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet68
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet72
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet76
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet8
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet80
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet84
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet88
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet92
Dec  5 01:34:49.922468  NOTICE mux#linkmgrd: MuxManager.cpp:579 handleWarmRestartReconciliationTimeout: config mux mode back to auto for Ethernet96
```
Apply_view passed. 
```
admin@:~$ sudo zgrep -i "apply.*view" /var/log/syslog
Dec  5 01:35:02.553989  WARNING syncd#syncd: :- processNotifySyncd: syncd received APPLY VIEW, will translate
Dec  5 01:35:02.555374  NOTICE swss#orchagent: :- syncd_apply_view: Notify syncd APPLY_VIEW
Dec  5 01:35:02.555374  NOTICE swss#orchagent: :- notifySyncd: sending syncd: APPLY_VIEW
Dec  5 01:35:03.232332  NOTICE syncd#syncd: :- threadFunction: time span 678 ms for 'notify:APPLY_VIEW'
Dec  5 01:35:04.232475  NOTICE syncd#syncd: :- threadFunction: time span 1678 ms for 'notify:APPLY_VIEW'
Dec  5 01:35:04.641424  NOTICE syncd#syncd: :- applyViewTransition: loop removed 12 objects
Dec  5 01:35:04.647544  NOTICE syncd#syncd: :- applyViewTransition: loop removed 6 objects
Dec  5 01:35:04.652076  NOTICE syncd#syncd: :- applyViewTransition: comparison logic took 0.293566 sec
Dec  5 01:35:05.232537  NOTICE syncd#syncd: :- threadFunction: time span 2678 ms for 'notify:APPLY_VIEW'
Dec  5 01:35:06.232662  NOTICE syncd#syncd: :- threadFunction: time span 3678 ms for 'notify:APPLY_VIEW'
Dec  5 01:35:07.232764  NOTICE syncd#syncd: :- threadFunction: time span 4678 ms for 'notify:APPLY_VIEW'
Dec  5 01:35:08.232867  NOTICE syncd#syncd: :- threadFunction: time span 5678 ms for 'notify:APPLY_VIEW'
Dec  5 01:35:09.233140  NOTICE syncd#syncd: :- threadFunction: time span 6679 ms for 'notify:APPLY_VIEW'
Dec  5 01:35:09.323370  NOTICE syncd#syncd: :- applyView: apply took 6.735897 sec
Dec  5 01:35:09.324029  NOTICE swss#orchagent: :- sai_redis_notify_syncd: switched ASIC to APPLY VIEW
```
No mismatched tunnel entries, neighbor entries counters.
``` 
admin@:~$ sudo zgrep "logView" /var/log/syslog
Dec  5 01:35:04.348841  WARNING syncd#syncd: :- logViewObjectCount: object count for SAI_OBJECT_TYPE_HOSTIF_TRAP_GROUP on current view 5 is different than on temporary view: 1
Dec  5 01:35:04.348841  WARNING syncd#syncd: :- logViewObjectCount: object count for SAI_OBJECT_TYPE_POLICER on current view 3 is different than on temporary view: 0
Dec  5 01:35:04.349559  WARNING syncd#syncd: :- logViewObjectCount: object count for SAI_OBJECT_TYPE_HOSTIF_TRAP on current view 12 is different than on temporary view: 1
Dec  5 01:35:04.358593  WARNING syncd#syncd: :- logViewObjectCount: object count is different on both view, there will be ASIC OPERATIONS!
```

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->