### PR TITLE
Exclude `DbInterface` in PR coverage check

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -61,6 +61,7 @@ DbInterface::DbInterface(mux::MuxManager *muxManager, boost::asio::io_service *i
 {
 }
 
+// GCOVR_EXCL_START
 
 //
 // ---> getMuxState(const std::string &portName);
@@ -1556,5 +1557,7 @@ void DbInterface::handleSwssNotification()
     mBarrier.wait();
     mMuxManagerPtr->terminate();
 }
+
+// GCOVR_EXCL_STOP
 
 } /* namespace common */


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Linkmgrd unit tests overrides DbInterface functions with fake handlers and verified the invoking counters instead of interacting with real Redis Dbs. 

Hence, excluding Dbinterface.cpp from coverage checker. 

sign-off: Jing Zhang zhangjing@microsoft.com 


### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

##### Work item tracking
- Microsoft ADO **(number only)**:
16576022
#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->