### PR TITLE
[active-standby] Probe the link in suspend timeout

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -493,6 +493,7 @@ void ActiveStandbyStateMachine::handleStateChange(LinkProberEvent &event, link_p
 
     if (ps(mCompositeState) != link_prober::LinkProberState::Unknown) {
         mResumeTxFnPtr();
+        mUnknownActiveUpBackoffFactor = 1;
     }
 
     updateMuxLinkmgrState();

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -366,6 +366,9 @@ void ActiveStandbyStateMachine::handleSwssBladeIpv4AddressUpdate(boost::asio::ip
             mProbePeerTorFnPtr = boost::bind(
                 &link_prober::LinkProber::probePeerTor, mLinkProberPtr.get()
             );
+            mDetectLinkFnPtr = boost::bind(
+                &link_prober::LinkProber::detectLink, mLinkProberPtr.get()
+            );
             mSuspendTxFnPtr = boost::bind(
                 &link_prober::LinkProber::suspendTxProbes, mLinkProberPtr.get(), boost::placeholders::_1
             );
@@ -829,6 +832,8 @@ void ActiveStandbyStateMachine::handleSuspendTimerExpiry()
         CompositeState currState = mCompositeState;
         enterMuxWaitState(mCompositeState);
         LOGINFO_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), currState, mCompositeState);
+        // detect if link/server recovers
+        mDetectLinkFnPtr();
     } else {
         mUnknownActiveUpBackoffFactor = 1;
     }

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -756,6 +756,17 @@ private:
     void setProbePeerTorFnPtr(boost::function<void ()> probePeerTorFnPtr) {mProbePeerTorFnPtr = probePeerTorFnPtr;};
 
     /**
+    *@method setDetectLinkFnPtr
+    *
+    *@brief set new DetectLinkFnPtr for the state machine. This method is used for testing
+    *
+    *@param detectLinkFnPtr (in)  pointer to new DetectLinkFnPtr
+    *
+    *@return none
+    */
+    void setDetectLinkFnPtr(boost::function<void ()> detectLinkFnPtr) {mDetectLinkFnPtr = detectLinkFnPtr;};
+
+    /**
     *@method setSuspendTxFnPtr
     *
     *@brief set new SuspendTXFnPtr for the state machine. This method is used for testing
@@ -852,6 +863,7 @@ private:
     boost::function<void ()> mInitializeProberFnPtr;
     boost::function<void ()> mStartProbingFnPtr;
     boost::function<void ()> mProbePeerTorFnPtr;
+    boost::function<void ()> mDetectLinkFnPtr;
     boost::function<void (uint32_t suspendTime_msec)> mSuspendTxFnPtr;
     boost::function<void ()> mResumeTxFnPtr;
     boost::function<void ()> mSendPeerSwitchCommandFnPtr;

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -329,7 +329,7 @@ void LinkProber::handleSendProbeCommand()
 }
 
 //
-// ---> sendHeartbeat()
+// ---> sendHeartbeat(bool forceSend)
 //
 // send ICMP ECHOREQUEST packet
 //

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -235,29 +235,18 @@ void LinkProber::probePeerTor()
 }
 
 //
-// ---> detectLink(uint32_t probeCount);
-//
-// send HBs to detect the link status
-//
-void LinkProber::detectLink(uint32_t probeCount)
-{
-    boost::asio::io_service &ioService = mStrand.context();
-    for (uint32_t i = 0; i < probeCount; ++i)
-    {
-        ioService.post(mStrand.wrap(boost::bind(&LinkProber::sendHeartbeat, this, true)));
-    }
-}
-
-//
 // ---> detectLink();
 //
 // send HBs to detect the link status
 //
 void LinkProber::detectLink()
 {
-    detectLink(mMuxPortConfig.getPositiveStateChangeRetryCount());
+    boost::asio::io_service &ioService = mStrand.context();
+    for (uint32_t i = 0; i < mMuxPortConfig.getPositiveStateChangeRetryCount(); ++i)
+    {
+        ioService.post(mStrand.wrap(boost::bind(&LinkProber::sendHeartbeat, this, true)));
+    }
 }
-
 
 //
 // ---> sendPeerSwitchCommand();

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -230,9 +230,33 @@ void LinkProber::updateEthernetFrame()
 //
 void LinkProber::probePeerTor()
 {
-    boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(&LinkProber::sendHeartbeat, this)));
+    detectLink(1);
 }
+
+//
+// ---> detectLink(uint32_t probeCount);
+//
+// send HBs to detect the link status
+//
+void LinkProber::detectLink(uint32_t probeCount)
+{
+    boost::asio::io_service &ioService = mStrand.context();
+    for (uint32_t i = 0; i < probeCount; ++i)
+    {
+        ioService.post(mStrand.wrap(boost::bind(&LinkProber::sendHeartbeat, this)));
+    }
+}
+
+//
+// ---> detectLink();
+//
+// send HBs to detect the link status
+//
+void LinkProber::detectLink()
+{
+    detectLink(mMuxPortConfig.getPositiveStateChangeRetryCount());
+}
+
 
 //
 // ---> sendPeerSwitchCommand();

--- a/src/link_prober/LinkProber.h
+++ b/src/link_prober/LinkProber.h
@@ -286,9 +286,11 @@ private:
     *
     *@brief send ICMP ECHOREQUEST packet
     *
+    *@param forceSend (in)  Force sending heartbeat, used in link detect only
+    *
     *@return none
     */
-    void sendHeartbeat();
+    void sendHeartbeat(bool forceSend = false);
 
     /**
     *@method handleTlvCommandRecv

--- a/src/link_prober/LinkProber.h
+++ b/src/link_prober/LinkProber.h
@@ -172,17 +172,6 @@ public:
     *
     *@brief detect link status
     *
-    *@param probeCount (in) HB count
-    *
-    *@return none
-    */
-    void detectLink(uint32_t probeCount);
-
-    /**
-    *@method detectLink
-    *
-    *@brief detect link status
-    *
     *@return none
     */
     void detectLink();

--- a/src/link_prober/LinkProber.h
+++ b/src/link_prober/LinkProber.h
@@ -168,6 +168,26 @@ public:
     void probePeerTor();
 
     /**
+    *@method detectLink
+    *
+    *@brief detect link status
+    *
+    *@param probeCount (in) HB count
+    *
+    *@return none
+    */
+    void detectLink(uint32_t probeCount);
+
+    /**
+    *@method detectLink
+    *
+    *@brief detect link status
+    *
+    *@return none
+    */
+    void detectLink();
+
+    /**
     *@method sendPeerSwitchCommand
     *
     *@brief send switch command to peer ToR

--- a/test/FakeLinkProber.cpp
+++ b/test/FakeLinkProber.cpp
@@ -106,6 +106,13 @@ void FakeLinkProber::probePeerTor()
     mProbePeerTorCallCount++;
 }
 
+void FakeLinkProber::detectLink()
+{
+    MUXLOGINFO("");
+
+    mDetectLinkCallCount++;
+}
+
 void FakeLinkProber::suspendTxProbes(uint32_t suspendTime_msec)
 {
     MUXLOGINFO("");

--- a/test/FakeLinkProber.h
+++ b/test/FakeLinkProber.h
@@ -43,6 +43,7 @@ public:
     void startProbing();
     void updateEthernetFrame();
     void probePeerTor();
+    void detectLink();
     void suspendTxProbes(uint32_t suspendTime_msec);
     void resumeTxProbes();
     void sendPeerSwitchCommand();
@@ -62,6 +63,7 @@ public:
     uint32_t mUpdateEthernetFrameCallCount = 0;
     uint32_t mProbePeerTorCallCount = 0;
     uint32_t mSuspendTxProbeCallCount = 0;
+    uint32_t mDetectLinkCallCount = 0;
     uint32_t mResumeTxProbeCallCount = 0;
     uint32_t mSendPeerSwitchCommand = 0;
     uint32_t mSendPeerProbeCommand = 0;

--- a/test/FakeMuxPort.cpp
+++ b/test/FakeMuxPort.cpp
@@ -117,6 +117,9 @@ inline void FakeMuxPort::initLinkProberActiveStandby()
     getActiveStandbyStateMachinePtr()->setProbePeerTorFnPtr(
         boost::bind(&FakeLinkProber::probePeerTor, mFakeLinkProber.get())
     );
+    getActiveStandbyStateMachinePtr()->setDetectLinkFnPtr(
+        boost::bind(&FakeLinkProber::detectLink, mFakeLinkProber.get())
+    );
     getActiveStandbyStateMachinePtr()->setSuspendTxFnPtr(
         boost::bind(&FakeLinkProber::suspendTxProbes, mFakeLinkProber.get(), boost::placeholders::_1)
     );


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #208

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Fix the issue:
After the link probe `unknown`, the `standby` ToR fails to take the link.
When the link recovers, the `active` ToR is stuck in heartbeat suspension.

##### Work item tracking
- Microsoft ADO **(number only)**: 26281338

#### How did you do it?
Let's probe the link in suspension timeout if current state is (unknown, active, up).
Kudos to @zjswhhh to point out we should force sending the heartbeat in link detect.

#### How did you verify/test it?
UT and verify on testbed.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->