### PR TITLE
[active-standby] reset mux probing backoff factor in link flaps

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -567,6 +567,9 @@ void ActiveStandbyStateMachine::handleStateChange(LinkStateEvent &event, link_st
             // There is a problem with this approach as it will hide link flaps that result in lost heart-beats.
             initLinkProberState(nextState, true);
 //            enterMuxWaitState(nextState);
+
+            // reset mux probing backoff factor when link goes up
+            mMuxUnknownBackoffFactor = 1;
         } else if (ls(mCompositeState) == link_state::LinkState::Up &&
                    ls(nextState) == link_state::LinkState::Down &&
                    ms(mCompositeState) != mux_state::MuxState::Label::Standby) {

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -578,6 +578,10 @@ void ActiveStandbyStateMachine::handleStateChange(LinkStateEvent &event, link_st
 
             mActiveUnknownUpCount = 0;
             mStandbyUnknownUpCount = 0;
+
+            mWaitActiveUpCount = 0;
+            mWaitStandbyUpBackoffFactor = 1;
+            mUnknownActiveUpBackoffFactor = 1;
         } else {
             mStateTransitionHandler[ps(nextState)][ms(nextState)][ls(nextState)](nextState);
         }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

This PR is to address consistency in PXE boot scenario. In PXE boot, there is no ICMP heartbeats. During booting up, `standby` might switch to `active`. Mux probing is now the only way to find out mux toggles. But it's also expected to see mux probing fail when link is down, backoff factor can already be maximum when link is up. 

If we don't reset backoff factor, it might take ~40s for peer to correct the inconsistency. 

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

##### Work item tracking
- Microsoft ADO **(number only)**:
467321367  

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->