### PR TITLE
[active-standby] add knob to enable/disable oscillation 

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -1083,6 +1083,30 @@ void DbInterface::processMuxLinkmgrConfigNotifiction(std::deque<swss::KeyOpField
                     v
                 );
             }
+        } else if (key == "TIMED_OSCILLATION") {
+            std::string operation = kfvOp(entry);
+            std::vector<swss::FieldValueTuple> fieldValues = kfvFieldsValues(entry);
+
+            for (auto &fieldValue: fieldValues) {
+                std::string f = fvField(fieldValue);
+                std::string v = fvValue(fieldValue);
+                if (f == "oscillation_enabled") {
+                        if (v == "true") {
+                            mMuxManagerPtr->setOscillationEnabled(true);
+                        } else if (v == "false"){
+                            mMuxManagerPtr->setOscillationEnabled(false);
+                        }
+                } else if (f == "interval_sec") {
+                    mMuxManagerPtr->setOscillationInterval_sec(boost::lexical_cast<uint32_t> (v));
+                }
+
+                MUXLOGINFO(boost::format("key: %s, Operation: %s, f: %s, v: %s") %
+                    key %
+                    operation %
+                    f %
+                    v
+                );
+            }
         }
     }
 }

--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -1097,7 +1097,11 @@ void DbInterface::processMuxLinkmgrConfigNotifiction(std::deque<swss::KeyOpField
                             mMuxManagerPtr->setOscillationEnabled(false);
                         }
                 } else if (f == "interval_sec") {
-                    mMuxManagerPtr->setOscillationInterval_sec(boost::lexical_cast<uint32_t> (v));
+                    try {
+                        mMuxManagerPtr->setOscillationInterval_sec(boost::lexical_cast<uint32_t> (v));
+                    } catch (boost::bad_lexical_cast const &badLexicalCast) {
+                        MUXLOGWARNING(boost::format("bad lexical cast: %s") % badLexicalCast.what());
+                    }
                 }
 
                 MUXLOGINFO(boost::format("key: %s, Operation: %s, f: %s, v: %s") %

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -124,6 +124,28 @@ public:
     inline void setTimeoutIpv6_msec(uint32_t timeout_msec) {mMuxConfig.setTimeoutIpv6_msec(timeout_msec);};
 
     /**
+    *@method setOscillationEnabled
+    *
+    *@brief setter for enable/disable oscillation
+    *
+    *@param enable (in)  true to enable oscillation
+    *
+    *@return none
+    */
+    inline void setOscillationEnabled(bool enable) {mMuxConfig.setOscillationEnabled(enable);};
+
+    /**
+    *@method setOscillationInterval_sec
+    *
+    *@brief setter for oscillation interval in sec
+    *
+    *@param interval_sec (in)  interval in sec
+    *
+    *@return none
+    */
+    inline void setOscillationInterval_sec(uint32_t interval_sec) {mMuxConfig.setOscillationInterval_sec(interval_sec);};
+
+    /**
     *@method setLinkProberStatUpdateIntervalCount
     *
     *@brief setter for link prober stats posting interval

--- a/src/common/MuxConfig.h
+++ b/src/common/MuxConfig.h
@@ -98,6 +98,17 @@ public:
     inline void setTimeoutIpv6_msec(uint32_t timeout_msec) {mTimeoutIpv6_msec = timeout_msec;};
 
     /**
+    *@method setOscillationEnabled
+    *
+    *@brief setter for enabling/disabling mux state oscillation
+    *
+    *@param enable (in)  enable/disable mux state oscillation
+    *
+    *@return none
+    */
+    inline void setOscillationEnabled(bool enable) {mEnableTimedOscillationWhenNoHeartbeat = enable;};
+
+    /**
     *@method setLinkProberStatUpdateIntervalCount
     *
     *@brief setter for link prober stats posting interval
@@ -275,6 +286,15 @@ public:
     inline uint32_t getSuspendTimeout_msec() const {return (mNegativeStateChangeRetryCount + 1) * mTimeoutIpv4_msec;};
 
     /**
+    *@method getIfOscillationEnabled
+    *
+    *@brief getter for oscillation flag
+    *
+    *@return oscillation flag
+    */
+    inline bool getIfOscillationEnabled() const {return mEnableTimedOscillationWhenNoHeartbeat;};
+
+    /**
     *@method getOscillationInterval_sec
     *
     *@brief getter for mux state oscillation interval
@@ -433,7 +453,6 @@ public:
 
 private:
     uint8_t mNumberOfThreads = 5;
-    uint32_t mOscillationTimeout_sec = 300;
     uint32_t mTimeoutIpv4_msec = 100;
     uint32_t mTimeoutIpv6_msec = 1000;
     uint32_t mPositiveStateChangeRetryCount = 1;
@@ -442,6 +461,9 @@ private:
     uint32_t mSuspendTimeout_msec = 500;
     uint32_t mMuxStateChangeRetryCount = 1;
     uint32_t mLinkStateChangeRetryCount = 1;
+
+    bool mEnableTimedOscillationWhenNoHeartbeat = true;
+    uint32_t mOscillationTimeout_sec = 300;
 
     bool mEnableSwitchoverMeasurement = false;
     uint32_t mDecreasedTimeoutIpv4_msec = 10;

--- a/src/common/MuxPortConfig.h
+++ b/src/common/MuxPortConfig.h
@@ -193,6 +193,15 @@ public:
     inline uint32_t getLinkWaitTimeout_msec() const {return mMuxConfig.getSuspendTimeout_msec();};
 
     /**
+    *@method getIfOscillationEnabled
+    *
+    *@brief getter for mux state oscillation enable flag
+    *
+    *@return oscillation enable flag
+    */
+    inline bool getIfOscillationEnabled() const {return mMuxConfig.getIfOscillationEnabled();};
+
+    /**
     *@method getOscillationInterval_sec
     *
     *@brief getter for mux state oscillation interval

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -1083,7 +1083,8 @@ void ActiveStandbyStateMachine::handleOscillationTimeout(boost::system::error_co
 {
     MUXLOGDEBUG(mMuxPortConfig.getPortName());
 
-    if (errorCode == boost::system::errc::success &&
+    if (mMuxPortConfig.getIfOscillationEnabled() &&
+        errorCode == boost::system::errc::success &&
         ps(mCompositeState) == link_prober::LinkProberState::Label::Wait &&
         ms(mCompositeState) == mux_state::MuxState::Label::Active &&
         ls(mCompositeState) == link_state::LinkState::Label::Up) {

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -687,8 +687,6 @@ TEST_P(OscillationIntervalTest, OscillationInterval)
     };
     processMuxLinkmgrConfigNotifiction(entries);
 
-    runIoService();
-
     EXPECT_TRUE(getOscillationInterval_sec(port) == std::get<1>(GetParam()));
 }
 
@@ -711,8 +709,6 @@ TEST_F(MuxManagerTest, OscillationDisabled)
         {"TIMED_OSCILLATION", "SET", {{"oscillation_enabled", "false"}}}
     };
     processMuxLinkmgrConfigNotifiction(entries);
-
-    runIoService();
 
     EXPECT_TRUE(getOscillationEnabled(port) == false);
 }

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -683,7 +683,7 @@ TEST_P(OscillationIntervalTest, OscillationInterval)
     createPort(port);
 
     std::deque<swss::KeyOpFieldsValuesTuple> entries = {
-        {"TIMED_OSCILLATION", "SET", {{"oscillation_interval", std::get<0>(GetParam())}}}
+        {"TIMED_OSCILLATION", "SET", {{"interval_sec", std::get<0>(GetParam())}}}
     };
     processMuxLinkmgrConfigNotifiction(entries);
 

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -698,7 +698,7 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Values(
         std::make_tuple("1200", 1200),
         std::make_tuple("1", 300),
-        std::make_tuple("invalid", 300),
+        std::make_tuple("invalid", 300)
     )
 );
 

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -479,6 +479,20 @@ void MuxManagerTest::resetUpdateEthernetFrameFn(const std::string &portName)
     }
 }
 
+uint32_t MuxManagerTest::getOscillationInterval_sec(std::string port)
+{
+    std::shared_ptr<mux::MuxPort> muxPortPtr = mMuxManagerPtr->mPortMap[port];
+
+    return muxPortPtr->mMuxPortConfig.getOscillationInterval_sec();
+}
+
+bool MuxManagerTest::getOscillationEnabled(std::string port)
+{
+    std::shared_ptr<mux::MuxPort> muxPortPtr = mMuxManagerPtr->mPortMap[port];
+
+    return muxPortPtr->mMuxPortConfig.getIfOscillationEnabled();
+}
+
 TEST_F(MuxManagerTest, UpdatePortCableTypeActiveStandby)
 {
     std::string port = MuxManagerTest::PortName;
@@ -661,6 +675,46 @@ TEST_F(MuxManagerTest, SrcMacAddressUpdate)
 
     runIoService();
     EXPECT_TRUE(mFakeLinkProber->mUpdateEthernetFrameCallCount == updateEthernetFrameCallCountBefore + 1);
+}
+
+TEST_P(OscillationIntervalTest, OscillationInterval)
+{
+    std::string port = "Ethernet0";
+    createPort(port);
+
+    std::deque<swss::KeyOpFieldsValuesTuple> entries = {
+        {"TIMED_OSCILLATION", "SET", {{"oscillation_interval", std::get<0>(GetParam())}}}
+    };
+    processMuxLinkmgrConfigNotifiction(entries);
+
+    runIoService();
+
+    EXPECT_TRUE(getOscillationInterval_sec(port) == std::get<1>(GetParam()));
+}
+
+INSTANTIATE_TEST_CASE_P(
+    OscillationInterval,
+    OscillationIntervalTest,
+    ::testing::Values(
+        std::make_tuple("1200", 1200),
+        std::make_tuple("1", 300),
+        std::make_tuple("invalid", 300),
+    )
+);
+
+TEST_F(MuxManagerTest, OscillationDisabled)
+{
+    std::string port = "Ethernet0";
+    createPort(port);
+
+    std::deque<swss::KeyOpFieldsValuesTuple> entries = {
+        {"TIMED_OSCILLATION", "SET", {{"oscillation_enabled", "false"}}}
+    };
+    processMuxLinkmgrConfigNotifiction(entries);
+
+    runIoService();
+
+    EXPECT_TRUE(getOscillationEnabled(port) == false);
 }
 
 TEST_F(MuxManagerTest, ServerMacAddress)

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -56,9 +56,11 @@ public:
     uint32_t getTimeoutIpv4_msec(std::string port);
     uint32_t getTimeoutIpv6_msec(std::string port);
     uint32_t getLinkWaitTimeout_msec(std::string port);
+    uint32_t getOscillationInterval_sec(std::string port);
     bool getIfUseWellKnownMac(std::string port);
     bool setUseWellKnownMacActiveActive(bool use);
     bool getIfUseToRMac(std::string port);
+    bool getOscillationEnabled(std::string port);
     boost::asio::ip::address getBladeIpv4Address(std::string port);
     std::array<uint8_t, ETHER_ADDR_LEN> getBladeMacAddress(std::string port);
     std::array<uint8_t, ETHER_ADDR_LEN> getLastUpdatedMacAddress(std::string port);
@@ -120,6 +122,11 @@ class GetMuxStateTest: public MuxManagerTest,
 
 class MuxConfigUpdateTest: public MuxManagerTest,
                            public testing::WithParamInterface<std::tuple<std::string, common::MuxPortConfig::Mode, common::MuxPortConfig::PortCableType>>
+{
+};
+
+class OscillationIntervalTest: public MuxManagerTest,
+                               public testing::WithParamInterface<std::tuple<std::string, uint32_t>>
 {
 };
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

Add knob to enable/disable oscillation.

sign-off: Jing Zhang zhangjing@microsoft.com

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
To avoid test flakiness. 
 
##### Work item tracking
- Microsoft ADO **(number only)**:
- 28187403

#### How did you do it?
1. Add DB interface to enable/disable the oscillation feature
2. Add DB interface to config the oscillation interval 

#### How did you verify/test it?
Tested on lab device: 
1.  Knob was default on 
2.  Turned it off
3. Turned it on
4. Changed the interval 

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->