### PR TITLE
[active-standby] Fix default route handler race condition

### DIFF
--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -369,12 +369,11 @@ void MuxPort::handleDefaultRouteState(const std::string &routeState)
         state = link_manager::LinkManagerStateMachineBase::DefaultRoute::NA;
     }
 
-    boost::asio::io_service &ioService = mStrand.context();
-    ioService.post(mStrand.wrap(boost::bind(
+    boost::asio::post(mStrand, boost::bind(
         &link_manager::LinkManagerStateMachineBase::handleDefaultRouteStateNotification,
         mLinkManagerStateMachinePtr.get(),
         state
-    )));
+    ));
 }
 
 // 

--- a/test/FakeMuxPort.h
+++ b/test/FakeMuxPort.h
@@ -63,7 +63,7 @@ public:
     link_prober::LinkProberStateMachineBase* getLinkProberStateMachinePtr() { return getLinkManagerStateMachinePtr()->getLinkProberStateMachinePtr().get(); };
     mux_state::MuxStateMachine& getMuxStateMachine() { return getLinkManagerStateMachinePtr()->getMuxStateMachine(); };
     link_state::LinkStateMachine& getLinkStateMachine() { return getLinkManagerStateMachinePtr()->getLinkStateMachine(); };
-    link_manager::LinkManagerStateMachineBase::DefaultRoute getDefaultRoute() { return getLinkManagerStateMachinePtr()->getDefaultRouteState(); };
+    link_manager::LinkManagerStateMachineBase::DefaultRoute getDefaultRouteState() { return getLinkManagerStateMachinePtr()->getDefaultRouteState(); };
 
     bool getPendingMuxModeChange() { return getActiveStandbyStateMachinePtr()->mPendingMuxModeChange; };
     common::MuxPortConfig::Mode getTargetMuxMode() { return getActiveStandbyStateMachinePtr()->mTargetMuxMode; };

--- a/test/FakeMuxPort.h
+++ b/test/FakeMuxPort.h
@@ -63,6 +63,7 @@ public:
     link_prober::LinkProberStateMachineBase* getLinkProberStateMachinePtr() { return getLinkManagerStateMachinePtr()->getLinkProberStateMachinePtr().get(); };
     mux_state::MuxStateMachine& getMuxStateMachine() { return getLinkManagerStateMachinePtr()->getMuxStateMachine(); };
     link_state::LinkStateMachine& getLinkStateMachine() { return getLinkManagerStateMachinePtr()->getLinkStateMachine(); };
+    link_manager::LinkManagerStateMachineBase::DefaultRoute getDefaultRoute() { return getLinkManagerStateMachinePtr()->getDefaultRouteState(); };
 
     bool getPendingMuxModeChange() { return getActiveStandbyStateMachinePtr()->mPendingMuxModeChange; };
     common::MuxPortConfig::Mode getTargetMuxMode() { return getActiveStandbyStateMachinePtr()->mTargetMuxMode; };

--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -37,7 +37,6 @@ namespace test
 {
 
 LinkManagerStateMachineTest::LinkManagerStateMachineTest() :
-    mWork(mIoService),
     mDbInterfacePtr(std::make_shared<FakeDbInterface> (&mIoService)),
     mFakeMuxPort(
         mDbInterfacePtr,
@@ -73,6 +72,7 @@ void LinkManagerStateMachineTest::runIoService(uint32_t count)
 
 void LinkManagerStateMachineTest::runIoServiceThreaded(uint32_t count)
 {
+    mWork = std::make_unique<boost::asio::io_service::work>(mIoService);
     for (uint8_t i = 0; i < count; i++) {
         mThreadGroup.create_thread(boost::bind(&boost::asio::io_service::run, &mIoService));
     }
@@ -80,6 +80,7 @@ void LinkManagerStateMachineTest::runIoServiceThreaded(uint32_t count)
 
 void LinkManagerStateMachineTest::stopIoServiceThreaded()
 {
+    mWork.reset();
     mIoService.stop();
     mThreadGroup.join_all();
 }
@@ -1564,7 +1565,7 @@ TEST_F(LinkManagerStateMachineTest, DefaultRouteStateRaceCondition)
             ++check;
         }
 
-        EXPECT_EQ(mFakeMuxPort.getDefaultRoute(), link_manager::LinkManagerStateMachineBase::DefaultRoute::OK);
+        EXPECT_EQ(mFakeMuxPort.getDefaultRouteState(), link_manager::LinkManagerStateMachineBase::DefaultRoute::OK);
         EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount, i + 1);
         EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount, i + 1);
     }

--- a/test/LinkManagerStateMachineTest.h
+++ b/test/LinkManagerStateMachineTest.h
@@ -24,6 +24,7 @@
 #ifndef LINKMANAGERSTATEMACHINETEST_H_
 #define LINKMANAGERSTATEMACHINETEST_H_
 
+#include <memory>
 #include "gtest/gtest.h"
 
 #include "FakeMuxPort.h"
@@ -60,7 +61,7 @@ public:
 
 public:
     boost::asio::io_service mIoService;
-    boost::asio::io_service::work mWork;
+    std::unique_ptr<boost::asio::io_service::work> mWork;
     boost::thread_group mThreadGroup;
     common::MuxConfig mMuxConfig;
     std::shared_ptr<FakeDbInterface> mDbInterfacePtr;

--- a/test/LinkManagerStateMachineTest.h
+++ b/test/LinkManagerStateMachineTest.h
@@ -39,6 +39,8 @@ public:
     virtual ~LinkManagerStateMachineTest() = default;
 
     void runIoService(uint32_t count = 0);
+    void runIoServiceThreaded(uint32_t count = 3);
+    void stopIoServiceThreaded();
     void postLinkProberEvent(link_prober::LinkProberState::Label label, uint32_t count = 0, uint32_t detect_multiplier = 0);
     void postMuxEvent(mux_state::MuxState::Label label, uint32_t count = 0);
     void postLinkEvent(link_state::LinkState::Label label, uint32_t count = 0);
@@ -58,6 +60,8 @@ public:
 
 public:
     boost::asio::io_service mIoService;
+    boost::asio::io_service::work mWork;
+    boost::thread_group mThreadGroup;
     common::MuxConfig mMuxConfig;
     std::shared_ptr<FakeDbInterface> mDbInterfacePtr;
     std::string mPortName = "EtherTest01";


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Fix the race condition of the default route notification.

This is similar to https://github.com/sonic-net/sonic-linkmgrd/pull/104

If there are multiple default route notifications received by `linkmgrd`, the mux port posts the default route handlers wrapped by strand. But boost asio doesn't guarantee the execution order of the default route handlers, so the final state machine default route could be any intermediate default route state.

For example, for default route notifications like:
```
[2024-06-20 08:28:57.872911] [warning] MuxPort.cpp:365 handleDefaultRouteState: port: EtherTest01, state db default route state: na
[2024-06-20 08:28:57.872954] [warning] MuxPort.cpp:365 handleDefaultRouteState: port: EtherTest01, state db default route state: ok
```
The final state machine default route state could be "ok" if the handler for "ok" is executed after the handler for "na".
The final state machine default route state could be "na" if the handler for "ok" is executed before the handler for "na".

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

##### Work item tracking
- Microsoft ADO **(number only)**: 28471183

#### How did you do it?
post the default route handlers directly through strand instead of using `strand::wrap`, so the handlers are executed in the same order as the handlers' post order.

#### How did you verify/test it?
* without this PR, UT fail:
```
lolv@f8c780888096:/sonic/src/repo/sonic-linkmgrd$ ./linkmgrd-test --gtest_filter="*DefaultRouteStateRaceCondition*"
Note: Google Test filter = *DefaultRouteStateRaceCondition*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from LinkManagerStateMachineTest
[ RUN      ] LinkManagerStateMachineTest.DefaultRouteStateRaceCondition
test/LinkManagerStateMachineTest.cpp:1567: Failure
Expected equality of these values:
  mFakeMuxPort.getDefaultRoute()
    Which is: 4-byte object <01-00 00-00>
  link_manager::LinkManagerStateMachineBase::DefaultRoute::OK
    Which is: 4-byte object <02-00 00-00>
[  FAILED  ] LinkManagerStateMachineTest.DefaultRouteStateRaceCondition (11327 ms)
[----------] 1 test from LinkManagerStateMachineTest (11327 ms total)
 
[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (11328 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] LinkManagerStateMachineTest.DefaultRouteStateRaceCondition
 
1 FAILED TEST
```
* with this PR, UT pass:
```
lolv@f8c780888096:/sonic/src/repo/sonic-linkmgrd$ ./linkmgrd-test --gtest_filter="*DefaultRouteStateRaceCondition*"
Note: Google Test filter = *DefaultRouteStateRaceCondition*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from LinkManagerStateMachineTest
[ RUN      ] LinkManagerStateMachineTest.DefaultRouteStateRaceCondition
[       OK ] LinkManagerStateMachineTest.DefaultRouteStateRaceCondition (11496 ms)
[----------] 1 test from LinkManagerStateMachineTest (11496 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (11496 ms total)
[  PASSED  ] 1 test.
```

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->