### PR TITLE
Fix default route race condition UT

### DIFF
--- a/test/LinkManagerStateMachineTest.cpp
+++ b/test/LinkManagerStateMachineTest.cpp
@@ -1551,7 +1551,7 @@ TEST_F(LinkManagerStateMachineTest, DefaultRouteStateRaceCondition)
     runIoServiceThreaded(3);
 
     mMuxConfig.enableDefaultRouteFeature(true);
-    for (int i = 0; i < 10000; ++i)
+    for (uint i = 0; i < 10000; ++i)
     {
         MUXLOGDEBUG(boost::format("Iteration %d") % i);
         mFakeMuxPort.handleDefaultRouteState("na");
@@ -1559,9 +1559,9 @@ TEST_F(LinkManagerStateMachineTest, DefaultRouteStateRaceCondition)
 
         int check = 0;
         while (((mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount < i + 1) ||
-                (mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount < i + 1)) && (check < 10))
+                (mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount < i + 1)) && (check < 4000))
         {
-            usleep(1000);
+            usleep(2000);
             ++check;
         }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Fix the UT failure introduced by https://github.com/sonic-net/sonic-linkmgrd/pull/254.
The failure is due to that, the wait time for the two default route handlers to finish is 10ms, which is not sufficient on some build image agents which has limited CPU resource.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

##### Work item tracking
- Microsoft ADO **(number only)**: 28471183

#### How did you do it?
Let's increase the wait time to 8s.

#### How did you verify/test it?
UT passed.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->