### PR TITLE
[active-standby] Fix the oscillation logic

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -475,9 +475,7 @@ void ActiveStandbyStateMachine::handleStateChange(LinkProberEvent &event, link_p
 
             mStandbyUnknownUpCount = 0;
 
-            if (mOscillationTimerAlive) {
-                cancelOscillationTimer();
-            }
+            tryCancelOscillationTimerIfAlive();
         }
          
         if (state == link_prober::LinkProberState::Label::Standby) {
@@ -485,9 +483,7 @@ void ActiveStandbyStateMachine::handleStateChange(LinkProberEvent &event, link_p
 
             mActiveUnknownUpCount = 0;
 
-            if (mOscillationTimerAlive) {
-                cancelOscillationTimer();
-            }
+            tryCancelOscillationTimerIfAlive();
         }
 
         CompositeState nextState = mCompositeState;
@@ -548,8 +544,8 @@ void ActiveStandbyStateMachine::handleStateChange(MuxStateEvent &event, mux_stat
         mStandbyUnknownUpCount = 0;
     }
 
-    if (state == mux_state::MuxState::Label::Standby && mOscillationTimerAlive) {
-        cancelOscillationTimer();
+    if (state == mux_state::MuxState::Label::Standby) {
+        tryCancelOscillationTimerIfAlive();
     }
 
     updateMuxLinkmgrState();
@@ -593,9 +589,7 @@ void ActiveStandbyStateMachine::handleStateChange(LinkStateEvent &event, link_st
             mWaitStandbyUpBackoffFactor = 1;
             mUnknownActiveUpBackoffFactor = 1;
 
-            if (mOscillationTimerAlive) {
-                cancelOscillationTimer();
-            }
+            tryCancelOscillationTimerIfAlive();
         } else {
             mStateTransitionHandler[ps(nextState)][ms(nextState)][ls(nextState)](nextState);
         }
@@ -1091,15 +1085,17 @@ void ActiveStandbyStateMachine::startOscillationTimer()
 }
 
 //
-// ---> cancelOscillationTimer();
+// ---> tryCancelOscillationTimerIfAlive();
 //
-// cancel the oscillation timer
+// cancel the oscillation timer if it is alive
 //
-void ActiveStandbyStateMachine::cancelOscillationTimer()
+void ActiveStandbyStateMachine::tryCancelOscillationTimerIfAlive()
 {
-    MUXLOGINFO(boost::format("%s: cancel the oscillation timer") % mMuxPortConfig.getPortName());
-    mOscillationTimerAlive = false;
-    mOscillationTimer.cancel();
+    if (mOscillationTimerAlive) {
+        MUXLOGINFO(boost::format("%s: cancel the oscillation timer") % mMuxPortConfig.getPortName());
+        mOscillationTimerAlive = false;
+        mOscillationTimer.cancel();
+    }
 }
 
 //

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -465,6 +465,15 @@ private:
     void startOscillationTimer();
 
     /**
+    *@method cancelOscillationTimer
+    *
+    *@brief cancel the oscillation timer
+    *
+    *@return none
+    */
+    inline void cancelOscillationTimer();
+
+    /**
     *@method handleOscillationTimeout
     *
     *@brief handle when oscillation timer expires
@@ -859,6 +868,7 @@ private:
     boost::asio::deadline_timer mDeadlineTimer;
     boost::asio::deadline_timer mWaitTimer;
     boost::asio::deadline_timer mOscillationTimer;
+    bool mOscillationTimerAlive = false;
 
     boost::function<void ()> mInitializeProberFnPtr;
     boost::function<void ()> mStartProbingFnPtr;

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -465,13 +465,13 @@ private:
     void startOscillationTimer();
 
     /**
-    *@method cancelOscillationTimer
+    *@method tryCancelOscillationTimerIfAlive
     *
-    *@brief cancel the oscillation timer
+    *@brief cancel the oscillation timer if it is alive
     *
     *@return none
     */
-    inline void cancelOscillationTimer();
+    inline void tryCancelOscillationTimerIfAlive();
 
     /**
     *@method handleOscillationTimeout


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes #253

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Fix the unexpected toggle introduced by the oscillation logic.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

##### Work item tracking
- Microsoft ADO **(number only)**: 28397786

#### How did you do it?
The oscillation is introduced to allow the active side to toggle to standby if no heartbeat is received.
The workflow is described as the following:
```
(wait, active, up) ---> set oscillation timer [1]
...
(wait, active, up) ---> (wait, wait, up) [2]
(wait, wait, up) ---> (wait, active, up)
...
(wait, active, up) <--- oscillation timer expires, toggle to standby [3]
```
[1]: the ToR enters `(wait, active, up)`, no heartbeats received, oscillation timer is set.
[2]: the ToR consistently probes the mux status, and transits between `(wait, active, up)` and `(wait, wait, up)`.
[3]: when the oscillation timer expires and the ToR is `(wait, active, up)`, make the toggle to standby request.

We need to ensure that, the ToR is only allowed to transits between `(wait, active, up)` and `(wait, wait, up)` during [2]. So any link prober active/standby, mux standby, or link down events should cancel the oscillation.

#### How did you verify/test it?
UT

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->