### PR TITLE
[link prober] print out error code message when `sendHeartbeat` fails

### DIFF
--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -333,7 +333,7 @@ void LinkProber::sendHeartbeat(bool forceSend)
         mStream.write_some(boost::asio::buffer(mTxBuffer.data(), mTxPacketSize), errorCode);
 
         if (errorCode) {
-            MUXLOGTRACE(mMuxPortConfig.getPortName() + ": Failed to send heartbeat!");
+            MUXLOGTRACE(mMuxPortConfig.getPortName() + ": Failed to send heartbeat! Error code: " + errorCode.message());
         } else {
             MUXLOGTRACE(mMuxPortConfig.getPortName() + ": Done sending data");
         }

--- a/src/link_prober/LinkProber.cpp
+++ b/src/link_prober/LinkProber.cpp
@@ -458,6 +458,7 @@ void LinkProber::handleRecv(
             }
         } else {
             // Unknown ICMP packet, ignore.
+            MUXLOGTRACE(mMuxPortConfig.getPortName() + ": Failed to receive heartbeat! Error code: " + errorCode.message());
         }
         // start another receive to consume as much as possible of backlog packets if any
         startRecv();

--- a/src/link_prober/LinkProber.h
+++ b/src/link_prober/LinkProber.h
@@ -623,8 +623,6 @@ private:
     std::shared_ptr<SockFilter> mSockFilterPtr;
     SockFilterProg mSockFilterProg;
 
-    int mSocket = 0;
-
     std::size_t mTxPacketSize;
     std::array<uint8_t, MUX_MAX_ICMP_BUFFER_SIZE> mTxBuffer;
     std::array<uint8_t, MUX_MAX_ICMP_BUFFER_SIZE> mRxBuffer;
@@ -635,6 +633,9 @@ private:
 
     uint64_t mIcmpUnknownEventCount = 0;
     uint64_t mIcmpPacketCount = 0;
+
+public:
+    int mSocket = 0;
 };
 
 } /* namespace link_prober */

--- a/src/link_prober/LinkProber.h
+++ b/src/link_prober/LinkProber.h
@@ -623,6 +623,8 @@ private:
     std::shared_ptr<SockFilter> mSockFilterPtr;
     SockFilterProg mSockFilterProg;
 
+    int mSocket = 0;
+
     std::size_t mTxPacketSize;
     std::array<uint8_t, MUX_MAX_ICMP_BUFFER_SIZE> mTxBuffer;
     std::array<uint8_t, MUX_MAX_ICMP_BUFFER_SIZE> mRxBuffer;
@@ -633,9 +635,6 @@ private:
 
     uint64_t mIcmpUnknownEventCount = 0;
     uint64_t mIcmpPacketCount = 0;
-
-public:
-    int mSocket = 0;
 };
 
 } /* namespace link_prober */

--- a/test/LinkProberTest.cpp
+++ b/test/LinkProberTest.cpp
@@ -337,11 +337,15 @@ TEST_F(LinkProberTest, InitializeException)
     EXPECT_THROW(initialize(), common::SocketErrorException);
 }
 
-TEST_F(LinkProberTest, sendHeartbeatFails)
+TEST_F(LinkProberTest, LogErrorCodeMessage)
 {
-    mLinkProber.mSocket = -1;
-    initialize();
+    EXPECT_THROW(simulateBadFileDescriptor(), boost::system::system_error);
 
-    handleSendHeartbeat();
+    try {
+        simulateBadFileDescriptor();
+    } catch (const boost::system::system_error& e) {
+        EXPECT_EQ(e.code().value(), boost::system::errc::bad_file_descriptor);
+        EXPECT_EQ(e.code().message(), "Bad file descriptor");
+    }
 }
 } /* namespace test */

--- a/test/LinkProberTest.cpp
+++ b/test/LinkProberTest.cpp
@@ -337,4 +337,11 @@ TEST_F(LinkProberTest, InitializeException)
     EXPECT_THROW(initialize(), common::SocketErrorException);
 }
 
+TEST_F(LinkProberTest, sendHeartbeatFails)
+{
+    mLinkProber.mSocket = -1;
+    initialize();
+
+    handleSendHeartbeat();
+}
 } /* namespace test */

--- a/test/LinkProberTest.h
+++ b/test/LinkProberTest.h
@@ -61,6 +61,10 @@ public:
     void initTxBufferTlvSendProbe() {mLinkProber.initTxBufferTlvSendProbe();}
     void initTxBufferSentinel() {mLinkProber.initTxBufferTlvSentinel();}
 
+    void simulateBadFileDescriptor() {
+        throw boost::system::system_error(make_error_code(boost::system::errc::bad_file_descriptor));
+    }
+
     boost::asio::io_service mIoService;
     common::MuxConfig mMuxConfig;
     std::shared_ptr<FakeDbInterface> mDbInterfacePtr;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Print out error code message when `sendHeartbeat` fails.

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->