### PR TITLE
[active-active] Fix extra toggle after default route N/A

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -780,7 +780,7 @@ void ActiveActiveStateMachine::LinkProberActiveMuxStandbyLinkUpTransitionFunctio
             // last siwtch mux state to standby failed, try again
             switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
         }
-    } else {
+    } else if (mDefaultRouteState != DefaultRoute::NA) {
         switchMuxState(nextState, mux_state::MuxState::Label::Active);
     }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Fixes https://github.com/sonic-net/sonic-linkmgrd/issues/278

Fix the extra toggle after the default route `N/A`.
```
(active, active, up), ok                        <- default route n/a
                                                -> toggle to standby
(active, standby, up), n/a                      <- mux probe active from the periodically probe
(active, active, up), n/a                       <- mux state standby returned from the toggle to standby
(active, standby, up), n/a                      -> toggle to active
(active, active, up), n/a                       <- mux state active returned from the toggle to active
(active, active, up), n/a                       <- link prober unknown
(unknown, active, up), n/a                      -> toggle to standby
(unknown, standby, up), n/a                     <- mux state standby returned from toggle to standby
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

##### Work item tracking
- Microsoft ADO **(number only)**: 30186968

#### How did you do it?
Let's check the default route state when the mux transits into `(active, standby, up)`, if the default route state is `N/A`, skip the toggle to active.

#### How did you verify/test it?
UT

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->