### PR TITLE
Enforce switchover when target state is `standby` AND mux mode is `standby`

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -1034,7 +1034,8 @@ void ActiveActiveStateMachine::switchMuxState(
     if (forceSwitch ||
         mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto ||
         mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Detached ||
-        (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Active && label == mux_state::MuxState::Label::Active)) {
+        (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Active && label == mux_state::MuxState::Label::Active) ||
+        (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Standby && label == mux_state::MuxState::Label::Standby)) {
         MUXLOGWARNING(
             boost::format("%s: Switching MUX state to '%s'") %
             mMuxPortConfig.getPortName() %

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -384,6 +384,29 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveConfigStandby)
     VALIDATE_STATE(Active, Active, Up);
 }
 
+TEST_F(LinkManagerStateMachineActiveActiveTest, ConfigStandbySocAgentRestart)
+{
+    setMuxActive();
+
+    handleMuxConfig("standby", 1);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+    VALIDATE_STATE(Active, Standby, Up);
+
+    handleMuxState("standby", 3);
+    VALIDATE_STATE(Active, Standby, Up);
+
+    handleMuxState("active", 3);
+    VALIDATE_STATE(Active, Standby, Up);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
+
+    handleMuxConfig("auto", 1);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 4);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Active);
+    VALIDATE_STATE(Active, Active, Up);
+}
+
+
 TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveLinkProberPeerActive)
 {
     setMuxActive();

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -406,7 +406,6 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, ConfigStandbySocAgentRestart)
     VALIDATE_STATE(Active, Active, Up);
 }
 
-
 TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActiveLinkProberPeerActive)
 {
     setMuxActive();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Enforce switchover when target state is `standby` AND mux mode is `standby`. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Soc agent can always restart and set the forwarding state to default "active" on host side. If this happens during ToR maintenance ( mux mode != `auto`), we still need to correct the state to "standby". 

##### Work item tracking
- Microsoft ADO **(number only)**:
30158450

#### How did you do it?

#### How did you verify/test it?
UT

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->