### PR TITLE
[active-standby] support reset heartbeat suspend timer

### DIFF
--- a/src/DbInterface.cpp
+++ b/src/DbInterface.cpp
@@ -28,6 +28,7 @@
 #include <boost/bind/bind.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/tokenizer.hpp>
 
 #include "swss/netdispatcher.h"
 #include "swss/netlink.h"
@@ -1050,6 +1051,10 @@ void DbInterface::processMuxLinkmgrConfigNotifiction(std::deque<swss::KeyOpField
                         mMuxManagerPtr->processSrcMac(v == "ToRMac");
                     } else if (f == "interval_pck_loss_count_update") {
                         mMuxManagerPtr->setLinkProberStatUpdateIntervalCount(boost::lexical_cast<uint32_t> (v));
+                    } else if (f == "reset_suspend_timer") {
+                        boost::tokenizer<> tok(v);
+                        std::vector<std::string> ports(tok.begin(), tok.end());
+                        mMuxManagerPtr->processResetSuspendTimer(ports);
                     }
 
                     MUXLOGINFO(boost::format("key: %s, Operation: %s, f: %s, v: %s") %

--- a/src/MuxManager.cpp
+++ b/src/MuxManager.cpp
@@ -598,4 +598,21 @@ void MuxManager::handleTsaEnableNotification(bool enable)
     }
 }
 
+//
+// ---> processResetSuspendTimer
+//
+// process suspend timer reset requests
+//
+void MuxManager::processResetSuspendTimer(const std::vector<std::string> &portNames)
+{
+    for (const std::string &portName : portNames)
+    {
+        MUXLOGINFO(boost::format("%s: reset heartbeat suspend timer") % portName);
+        PortMapIterator portMapIterator = mPortMap.find(portName);
+        if (portMapIterator != mPortMap.end()) {
+            portMapIterator->second->handleResetSuspendTimer();
+        }
+    }
+}
+
 } /* namespace mux */

--- a/src/MuxManager.h
+++ b/src/MuxManager.h
@@ -495,6 +495,17 @@ public:
      */
     void handleTsaEnableNotification(bool enable);
 
+    /**
+    *@method processResetSuspendTimer
+    *
+    *@brief process suspend timer reset requests
+    *
+    *@param portNames (in)  mux ports to reset the suspend timer
+    *
+    *@return none
+    */
+    void processResetSuspendTimer(const std::vector<std::string> &portNames);
+
 private:
     /**
     *@method getMuxPortCableType

--- a/src/MuxPort.cpp
+++ b/src/MuxPort.cpp
@@ -437,4 +437,19 @@ void MuxPort::handleTsaEnable(bool enable)
     ));
 }
 
+//
+// ---> handleResetSuspendTimer();
+//
+// handle suspend timer reset
+//
+void MuxPort::handleResetSuspendTimer()
+{
+    MUXLOGWARNING(boost::format("%s: reset heartbeat suspend timer") % mMuxPortConfig.getPortName());
+
+    boost::asio::post(mStrand, boost::bind(
+        &link_manager::LinkManagerStateMachineBase::handleResetSuspendTimer,
+        mLinkManagerStateMachinePtr.get()
+    ));
+}
+
 } /* namespace mux */

--- a/src/MuxPort.h
+++ b/src/MuxPort.h
@@ -419,6 +419,15 @@ public:
      */
     void handleTsaEnable(bool enable);
 
+    /**
+     *@method handleResetSuspendTimer
+     *
+     *@brief handle reset suspend timer request
+     *
+     * @return none
+     */
+    void handleResetSuspendTimer();
+
 protected:
     friend class test::MuxManagerTest;
     friend class test::FakeMuxPort;

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -958,6 +958,22 @@ void ActiveStandbyStateMachine::handleResetLinkProberPckLossCount()
     mResetIcmpPacketCountsFnPtr();
 }
 
+// ---> handleResetSuspendTimer();
+//
+// reset the heartbeat suspend timer
+//
+void ActiveStandbyStateMachine::handleResetSuspendTimer()
+{
+    MUXLOGDEBUG(boost::format("%s: reset heartbeat suspend timer") % mMuxPortConfig.getPortName());
+
+    if (ps(mCompositeState) == link_prober::LinkProberState::Label::Unknown &&
+        ms(mCompositeState) == mux_state::MuxState::Label::Active &&
+        ls(mCompositeState) == link_state::LinkState::Label::Up) {
+        mUnknownActiveUpBackoffFactor = 1;
+        mResumeTxFnPtr();
+    }
+}
+
 //
 // ---> updateMuxLinkmgrState();
 //

--- a/src/link_manager/LinkManagerStateMachineActiveStandby.h
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.h
@@ -401,6 +401,15 @@ public:
     */
     void handleResetLinkProberPckLossCount();
 
+    /**
+     * @method handleResetSuspendTimer
+     *
+     * @brief reset the heartbeat suspend timer
+     *
+     * @return none
+     */
+    void handleResetSuspendTimer();
+
 private:
     /**
     *@method updateMuxLinkmgrState

--- a/src/link_manager/LinkManagerStateMachineBase.cpp
+++ b/src/link_manager/LinkManagerStateMachineBase.cpp
@@ -336,6 +336,15 @@ void LinkManagerStateMachineBase::handleResetLinkProberPckLossCount()
     MUXLOGINFO(mMuxPortConfig.getPortName());
 }
 
+// ---> handleResetSuspendTimer();
+//
+// reset the heartbeat suspend timer
+//
+void LinkManagerStateMachineBase::handleResetSuspendTimer()
+{
+    MUXLOGINFO(mMuxPortConfig.getPortName());
+}
+
 //
 // ---> postMuxStateEvent(mux_state::MuxState::Label label)
 //

--- a/src/link_manager/LinkManagerStateMachineBase.h
+++ b/src/link_manager/LinkManagerStateMachineBase.h
@@ -505,6 +505,15 @@ public:
      */
     virtual void handleResetLinkProberPckLossCount();
 
+    /**
+     * @method handleResetSuspendTimer
+     *
+     * @brief reset the heartbeat suspend timer
+     *
+     * @return none
+     */
+    virtual void handleResetSuspendTimer();
+
 public:
     /**
     *@method getLinkProberStateMachinePtr

--- a/src/link_prober/LinkProber.h
+++ b/src/link_prober/LinkProber.h
@@ -629,6 +629,7 @@ private:
     std::array<uint8_t, MUX_MAX_ICMP_BUFFER_SIZE> mTxBuffer;
     std::array<uint8_t, MUX_MAX_ICMP_BUFFER_SIZE> mRxBuffer;
 
+    bool mCancelSuspend = false;
     bool mSuspendTx = false;
     bool mShutdownTx = false;
     bool mDecreaseProbingInterval = false;

--- a/test/FakeMuxPort.h
+++ b/test/FakeMuxPort.h
@@ -73,6 +73,7 @@ public:
 
     link_prober::LinkProberState::Label getPeerLinkProberState() { return getActiveActiveStateMachinePtr()->mPeerLinkProberState; };
     mux_state::MuxState::Label getPeerMuxState() { return getActiveActiveStateMachinePtr()->mPeerMuxState; };
+    uint32_t getActiveStandbyStateMachineSuspendBackoffFactor() { return getActiveStandbyStateMachinePtr()->mUnknownActiveUpBackoffFactor; }
 
     inline void initLinkProberActiveActive();
     inline void initLinkProberActiveStandby();

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -223,6 +223,12 @@ void LinkManagerStateMachineActiveActiveTest::handleMuxConfig(std::string config
     }
 }
 
+void LinkManagerStateMachineActiveActiveTest::handleResetSuspendTimer(uint32_t count)
+{
+    mFakeMuxPort.handleResetSuspendTimer();
+    runIoService(count);
+}
+
 void LinkManagerStateMachineActiveActiveTest::activateStateMachine(bool enable_feature_default_route)
 {
     mMuxConfig.enableDefaultRouteFeature(enable_feature_default_route);
@@ -1208,6 +1214,19 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, StateMachineInitEventWithMultipl
     postLinkProberEvent(link_prober::LinkProberState::Active, 3);
     VALIDATE_STATE(Active, Standby, Up);
     EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+}
+
+TEST_F(LinkManagerStateMachineActiveActiveTest, ResetSuspendTimer)
+{
+    setMuxActive();
+
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSuspendTxProbeCallCount, 0);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mResumeTxProbeCallCount, 2);
+    // reset suspend timer is NOOP for active-active composite state machine
+    handleResetSuspendTimer();
+    VALIDATE_STATE(Active, Active, Up);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mSuspendTxProbeCallCount, 0);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mResumeTxProbeCallCount, 2);
 }
 
 } /* namespace test */

--- a/test/LinkManagerStateMachineActiveActiveTest.h
+++ b/test/LinkManagerStateMachineActiveActiveTest.h
@@ -43,6 +43,7 @@ public:
     void handleProbeMuxState(std::string, uint32_t count = 0);
     void handleLinkState(std::string linkState, uint32_t count = 0);
     void handleMuxConfig(std::string config, uint32_t count = 0, bool poll = false);
+    void handleResetSuspendTimer(uint32_t count = 0);
     void activateStateMachine(bool enable_feature_default_route=false);
     void setMuxActive();
     void setMuxStandby();

--- a/test/LinkManagerStateMachineTest.h
+++ b/test/LinkManagerStateMachineTest.h
@@ -51,6 +51,7 @@ public:
     void handleProbeMuxState(std::string, uint32_t count = 0);
     void handleLinkState(std::string linkState, uint32_t count = 0);
     void handleMuxConfig(std::string config, uint32_t count = 0);
+    void handleResetSuspendTimer(uint32_t count = 0);
     void activateStateMachine();
     void setMuxActive();
     void setMuxStandby();

--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -903,9 +903,11 @@ TEST_F(MuxManagerTest, LinkmgrdConfig)
         {"LINK_PROBER", "SET", {{"interval_v4", "abc"}}},
         {"LINK_PROBER", "SET", {{"src_mac", "ToRMac"}}},
         {"LINK_PROBER", "SET", {{"interval_pck_loss_count_update", "900"}}},
+        {"LINK_PROBER", "SET", {{"reset_suspend_timer", "Ethernet0"}}},
         {"MUXLOGGER", "SET", {{"log_verbosity", "warning"}}},
     };
     processMuxLinkmgrConfigNotifiction(entries);
+    runIoService(2);
 
     EXPECT_TRUE(getTimeoutIpv4_msec(port) == v4PorbeInterval);
     EXPECT_TRUE(getTimeoutIpv6_msec(port) == v6ProveInterval);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [x] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

This is inspired from https://github.com/sonic-net/sonic-mgmt/pull/16878; the active side could be stuck in the following loop if it cannot receive any heartbeats:
```
# (unknown, active, up) ----------------------------> (unknown, wait, up)
#         ^              suspend timeout, probe mux           |          
#         |                                                   |          
#         |                                                   |          
#         |                                                   |          
#         +---------------------------------------------------+          
#                mux active, suspend heartbeat with backoff
```

and the suspend timeout will backoff with max timeout as `128 * (negative retry + 1) * send interval`; during this period, the mux port is unable to detect link failures as no heartbeats sending.
This PR is to support reset the suspend timer/backoff.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

##### Work item tracking
- Microsoft ADO **(number only)**: 31339123

#### How did you do it?
Support reset heartbeat suspend timer for `active-standby` state machine.

#### How did you verify/test it?
UT

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->