### PR TITLE
[active-standby] shutdown link prober when starting as isolated

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveStandby.cpp
@@ -436,6 +436,10 @@ void ActiveStandbyStateMachine::activateStateMachine()
         LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
         mCompositeState = nextState;
 
+        if (mMuxPortConfig.ifEnableDefaultRouteFeature() == true)  {
+            shutdownOrRestartLinkProberOnDefaultRoute();
+        }
+
         mInitializeProberFnPtr();
         mStartProbingFnPtr();
 
@@ -921,10 +925,12 @@ void ActiveStandbyStateMachine::shutdownOrRestartLinkProberOnDefaultRoute()
     MUXLOGDEBUG(mMuxPortConfig.getPortName());
 
     if (mComponentInitState.all()) {
-        if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto && mDefaultRouteState == DefaultRoute::NA) {
+        if ((mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto ||
+             mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Standby) && 
+             mDefaultRouteState == DefaultRoute::NA) {
             mShutdownTxFnPtr();
         } else {
-            // If mux mode is in manual/standby/active mode, we should restart link prober. 
+            // If mux mode is in manual/active mode, we should restart link prober. 
             // If default route state is "ok", we should retart link prober.
             mRestartTxFnPtr();
         }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)
Noticed that if server does serving during LT0 ugprade, link flaps on both sides' ToR, T0 can't always take over as `active` after link is up. Cause in some cases the `shutdownTx` was skipped on LT0 due to state machine inactivated or `tsa_enabled` made mux mode `standby`. Logs attached in internal ADO. 

Adding a similar fix to https://github.com/sonic-net/sonic-linkmgrd/pull/130 for active-standby as well. 

sign-off: Jing Zhang zhangjing@microsoft.com 

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

##### Work item tracking
- Microsoft ADO **(number only)**:
32099536

#### How did you do it?

#### How did you verify/test it?
UTs

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->