### PR TITLE
[active-active] Fix mux not toggle to active in default route flapping

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -1294,6 +1294,7 @@ void ActiveActiveStateMachine::handleDefaultRouteStateNotification(const Default
 {
     MUXLOGWARNING(boost::format("%s: default route state %d") % mMuxPortConfig.getPortName() % static_cast<int>(routeState));
 
+    DefaultRoute oldRouteState = mDefaultRouteState;
     mDefaultRouteState = routeState;
     shutdownOrRestartLinkProberOnDefaultRoute();
 
@@ -1306,6 +1307,19 @@ void ActiveActiveStateMachine::handleDefaultRouteStateNotification(const Default
         switchMuxState(nextState, mux_state::MuxState::Label::Standby);
         LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
         mCompositeState = nextState;
+    }
+    if (mComponentInitState.all() &&
+        oldRouteState == DefaultRoute::NA && mDefaultRouteState == DefaultRoute::OK &&
+        ps(mCompositeState) == link_prober::LinkProberState::Label::Active &&
+        mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto) {
+        // Let's reset the link prober state if the default route flaps faster than
+        // the link prober detection.
+        MUXLOGWARNING(
+            boost::format("%s: reset link prober state, current mux state '%s' ") %
+            mMuxPortConfig.getPortName() %
+            mMuxStateName[ms(mCompositeState)]
+        );
+        initLinkProberState(mCompositeState);
     }
 
     updateMuxLinkmgrState();

--- a/test/LinkManagerStateMachineActiveActiveTest.cpp
+++ b/test/LinkManagerStateMachineActiveActiveTest.cpp
@@ -1229,4 +1229,28 @@ TEST_F(LinkManagerStateMachineActiveActiveTest, ResetSuspendTimer)
     EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mResumeTxProbeCallCount, 2);
 }
 
+TEST_F(LinkManagerStateMachineActiveActiveTest, MuxActivDefaultRouteFlap)
+{
+    setMuxActive();
+
+    mMuxConfig.enableDefaultRouteFeature(true);
+    postDefaultRouteEvent("na", 1);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount, 1);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount, 0);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 2);
+    EXPECT_EQ(mDbInterfacePtr->mLastSetMuxState, mux_state::MuxState::Label::Standby);
+    handleMuxState("standby", 3);
+    VALIDATE_STATE(Active, Standby, Up);
+
+    postDefaultRouteEvent("ok", 1);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mShutdownTxProbeCallCount, 1);
+    EXPECT_EQ(mFakeMuxPort.mFakeLinkProber->mRestartTxProbeCallCount, 1);
+    VALIDATE_STATE(Unknown, Standby, Up);
+
+    postLinkProberEvent(link_prober::LinkProberState::Active, 3);
+    handleMuxState("active", 3);
+    EXPECT_EQ(mDbInterfacePtr->mSetMuxStateInvokeCount, 3);
+    VALIDATE_STATE(Active, Active, Up);
+}
+
 } /* namespace test */


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
If the default route flaps faster than the link prober detection, the mux status remains `standby` even after default route `ok`:

```
(active, active, up) ----> default route n/a, toggle to standby, suspend sending heartbeat ---->
(active, standby, up) ----> default route ok, resume heartbeat sending ---->
(active, standby, up) ----> link prober active, noop ---->
(active, standby, up)
```

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

##### Work item tracking
- Microsoft ADO **(number only)**: 32625971

#### How did you do it?
Reset the link prober state in this case:
```
(active, active, up) ----> default route n/a, toggle to standby, suspend sending heartbeat ---->
(active, standby, up) ----> default route ok, resume heartbeat sending, reset link prober state ---->
(unknown, standby, up) ----> link prober active, toggle to active ---->
(active, active, up)
```

#### How did you verify/test it?
UT and on DUT.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->