### PR TITLE
[202411][active-active] Fix mux not toggle to active in default route flapping (#291)

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -1294,6 +1294,7 @@ void ActiveActiveStateMachine::handleDefaultRouteStateNotification(const Default
 {
     MUXLOGWARNING(boost::format("%s: default route state %d") % mMuxPortConfig.getPortName() % static_cast<int>(routeState));
 
+    DefaultRoute oldRouteState = mDefaultRouteState;
     mDefaultRouteState = routeState;
     shutdownOrRestartLinkProberOnDefaultRoute();
 
@@ -1306,6 +1307,19 @@ void ActiveActiveStateMachine::handleDefaultRouteStateNotification(const Default
         switchMuxState(nextState, mux_state::MuxState::Label::Standby);
         LOGWARNING_MUX_STATE_TRANSITION(mMuxPortConfig.getPortName(), mCompositeState, nextState);
         mCompositeState = nextState;
+    }
+    if (mComponentInitState.all() &&
+        oldRouteState == DefaultRoute::NA && mDefaultRouteState == DefaultRoute::OK &&
+        ps(mCompositeState) == link_prober::LinkProberState::Label::Active &&
+        mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Auto) {
+        // Let's reset the link prober state if the default route flaps faster than
+        // the link prober detection.
+        MUXLOGWARNING(
+            boost::format("%s: reset link prober state, current mux state '%s' ") %
+            mMuxPortConfig.getPortName() %
+            mMuxStateName[ms(mCompositeState)]
+        );
+        initLinkProberState(mCompositeState);
     }
 
     updateMuxLinkmgrState();


### PR DESCRIPTION




<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Cherry-pick https://github.com/sonic-net/sonic-linkmgrd/pull/291 into 202411

Signed-off-by: Longxiang Lyu lolv@microsoft.com


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->