### PR TITLE
Fix mux port `uninitialized`

### DIFF
--- a/src/link_prober/LinkProberBase.cpp
+++ b/src/link_prober/LinkProberBase.cpp
@@ -33,6 +33,7 @@ SockFilter LinkProberBase::mIcmpFilter[] = {
 };
 
 // Set to hold all the session id's accross all ports of system for both Normal/Rx
+std::recursive_mutex LinkProberBase::mGuidSetMtx;
 std::unordered_set<std::string> LinkProberBase::mGuidSet;
 
 LinkProberBase::LinkProberBase(common::MuxPortConfig &muxPortConfig, boost::asio::io_service &ioService,
@@ -712,6 +713,7 @@ std::string LinkProberBase::generateGuid()
     std::fill(generatedGuid.begin(), generatedGuid.end() - 4, 0);
     auto generatedGuidStr = uuidToHexString(generatedGuid);
     generatedGuidStr = "0x" + generatedGuidStr.substr(generatedGuidStr.length() - 8);
+    std::lock_guard<std::recursive_mutex> lock(mGuidSetMtx);
     if(mGuidSet.find(generatedGuidStr) == mGuidSet.end())
     {
         mGuidSet.insert(generatedGuidStr);

--- a/src/link_prober/LinkProberBase.h
+++ b/src/link_prober/LinkProberBase.h
@@ -7,6 +7,7 @@
 #include <linux/filter.h>
 #include <unordered_set>
 #include <iomanip>
+#include <mutex>
 
 #include <netpacket/packet.h>
 #include <sys/socket.h>
@@ -73,6 +74,8 @@ using SockAddrLinkLayer = struct sockaddr_ll;
 class LinkProberBase
 {
 public:
+    friend class test::LinkProberMockTest;
+
     enum SessionType {
         UNKNOWN,
         SOFTWARE,
@@ -395,6 +398,7 @@ public:
 
     void resetTxBufferTlv() {mTxPacketSize = mTlvStartOffset;};
 
+    static std::recursive_mutex mGuidSetMtx;
     static std::unordered_set<std::string> mGuidSet;
     boost::uuids::uuid mSelfUUID;
 

--- a/test/MockLinkProberTest.h
+++ b/test/MockLinkProberTest.h
@@ -53,6 +53,8 @@ public:
     void handleTimeout() { mLinkProberPtr->mReportHeartbeatReplyNotReceivedFuncPtr(link_prober::HeartbeatType::HEARTBEAT_SELF); }
     void receiveSelfIcmpReply();
     void receivePeerIcmpReply();
+    void postGenerateGuid(uint32_t count);
+    boost::asio::io_service &getIoService() {  return mIoService; }
 
 private:
     void buildIcmpReply();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
Fix #307 

The mux port health is `uninitialized` in nightly.
And from the syslog, the state machines are not activated as the link probers are trying to generate `GUID`. The `GUID` generation logic is stuck somehow in the multi-threading environment.
From the backtrace on each threads, some threads is busy looping the generated `GUID` set while some threads are trying to insert new `GUID` into the set; this is a race condition as the C++ multiset is not thread-safe.

Signed-off-by: Longxiang Lyu <lolv@microsoft.com>

##### Work item tracking
- Microsoft ADO **(number only)**: 34335369

#### How did you do it?
Let's wrap the generated `GUID` set update/read code section with a lock.

#### How did you verify/test it?
1. UT.
2. use the script in the issue, run over 12h, no repro.

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->