### PR TITLE
Fix periodic sync recovery when mux config mode differs from hardware state.

### DIFF
--- a/src/link_manager/LinkManagerStateMachineActiveActive.cpp
+++ b/src/link_manager/LinkManagerStateMachineActiveActive.cpp
@@ -784,6 +784,10 @@ void ActiveActiveStateMachine::LinkProberActiveMuxActiveLinkUpTransitionFunction
     if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Standby) {
         if (mLastMuxStateNotification != mux_state::MuxState::Label::Standby) {
             switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
+        } else if (mLastMuxNotificationType == LastMuxNotificationType::MuxNotificationFromProbe &&
+                   mLastMuxProbeNotification != mux_state::MuxState::Label::Standby) {
+            // Toggle succeeded but periodic sync detected hardware drift, correct it
+            switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
         }
     } else if (mLastMuxStateNotification == mux_state::MuxState::Label::Unknown) {
         // switch active to notify swss
@@ -803,6 +807,10 @@ void ActiveActiveStateMachine::LinkProberActiveMuxStandbyLinkUpTransitionFunctio
         if (mLastMuxStateNotification != mux_state::MuxState::Label::Standby) {
             // last siwtch mux state to standby failed, try again
             switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
+        } else if (mLastMuxNotificationType == LastMuxNotificationType::MuxNotificationFromProbe &&
+                   mLastMuxProbeNotification != mux_state::MuxState::Label::Standby) {
+            // Toggle succeeded but periodic sync detected hardware drift, correct it
+            switchMuxState(nextState, mux_state::MuxState::Label::Standby, true);
         }
     } else if (mDefaultRouteState != DefaultRoute::NA) {
         switchMuxState(nextState, mux_state::MuxState::Label::Active);
@@ -821,6 +829,10 @@ void ActiveActiveStateMachine::LinkProberUnknownMuxActiveLinkUpTransitionFunctio
         if (mLastMuxStateNotification != mux_state::MuxState::Label::Active) {
             // last switch mux state to active failed, try again
             switchMuxState(nextState, mux_state::MuxState::Label::Active, true);
+        } else if (mLastMuxNotificationType == LastMuxNotificationType::MuxNotificationFromProbe &&
+                   mLastMuxProbeNotification != mux_state::MuxState::Label::Active) {
+            // Toggle succeeded but periodic sync detected hardware drift, correct it
+            switchMuxState(nextState, mux_state::MuxState::Label::Active, true);
         }
     } else {
         switchMuxState(nextState, mux_state::MuxState::Label::Standby);
@@ -838,6 +850,10 @@ void ActiveActiveStateMachine::LinkProberUnknownMuxStandbyLinkUpTransitionFuncti
     if (mMuxPortConfig.getMode() == common::MuxPortConfig::Mode::Active) {
         if (mLastMuxStateNotification != mux_state::MuxState::Label::Active) {
             // last switch mux state to active failed, try again
+            switchMuxState(nextState, mux_state::MuxState::Label::Active, true);
+        } else if (mLastMuxNotificationType == LastMuxNotificationType::MuxNotificationFromProbe &&
+                   mLastMuxProbeNotification != mux_state::MuxState::Label::Active) {
+            // Toggle succeeded but periodic sync detected hardware drift, correct it
             switchMuxState(nextState, mux_state::MuxState::Label::Active, true);
         }
     } else if (mLastMuxStateNotification == mux_state::MuxState::Label::Unknown) {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
When mux is configured in manual mode (`active/standby`), periodic sync detects hardware drift but fails to trigger resync. After a successful toggle, `mLastMuxStateNotification` matches the expected state, so the existing check passes and no resync occurs even when probe detects drift. Fix by adding an `else-if` branch that checks `mLastMuxProbeNotification` when the notification came from a probe, triggering resync if hardware state differs from expected.
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->

Summary:
Fixes # (https://github.com/aristanetworks/sonic-qual.msft/issues/947)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?
When mux is configured in manual mode (`active/standby`), periodic sync detects hardware drift but fails to trigger resync.

##### Work item tracking
- Microsoft ADO **(number only)**: 35946943

#### How did you do it?
By adding an `else-i`f branch that checks `mLastMuxProbeNotification` when the notification came from a probe, triggering resync if hardware state differs from expected.


#### How did you verify/test it?
Ran `test_mux_forwarding_state_consistency`

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->