### PR TITLE
update docker slave name and switch to using libboost1.83

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,7 +129,7 @@ jobs:
   timeoutInMinutes: 180
   pool: sonicso1ES-arm64
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:${BUILD_BRANCH}-arm64
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)-arm64
 
   steps:
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,12 @@ trigger:
     include:
       - "*"
 
+variables:
+  - name: BUILD_BRANCH
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      value: $(System.PullRequest.TargetBranch)
+    ${{ else }}:
+      value: $(Build.SourceBranchName)
 
 jobs:
 - job:
@@ -20,7 +26,7 @@ jobs:
     vmImage: 'ubuntu-22.04'
 
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)
 
   steps:
   - script: |
@@ -33,23 +39,23 @@ jobs:
     displayName: install .Net
   - script: |
       sudo apt-get install -y\
-          libboost-dev \
-          libboost-program-options-dev \
-          libboost-system-dev \
-          libboost-thread-dev \
-          libboost-atomic-dev \
-          libboost-chrono-dev \
-          libboost-container-dev \
-          libboost-context-dev \
-          libboost-contract-dev \
-          libboost-coroutine-dev \
-          libboost-date-time-dev \
-          libboost-fiber-dev \
-          libboost-filesystem-dev \
-          libboost-graph-parallel-dev \
-          libboost-log-dev \
-          libboost-regex-dev \
-          libboost-serialization-dev \
+          libboost1.83-dev \
+          libboost-program-options1.83-dev \
+          libboost-system1.83-dev \
+          libboost-thread1.83-dev \
+          libboost-atomic1.83-dev \
+          libboost-chrono1.83-dev \
+          libboost-container1.83-dev \
+          libboost-context1.83-dev \
+          libboost-contract1.83-dev \
+          libboost-coroutine1.83-dev \
+          libboost-date-time1.83-dev \
+          libboost-fiber1.83-dev \
+          libboost-filesystem1.83-dev \
+          libboost-graph-parallel1.83-dev \
+          libboost-log1.83-dev \
+          libboost-regex1.83-dev \
+          libboost-serialization1.83-dev \
           googletest \
           libgtest-dev \
           libgmock-dev \
@@ -123,30 +129,30 @@ jobs:
   timeoutInMinutes: 180
   pool: sonicso1ES-arm64
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-arm64:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:${BUILD_BRANCH}-arm64
 
   steps:
   - script: |
       set -ex
       sudo apt-get update
       sudo apt-get install -y\
-          libboost-dev \
-          libboost-program-options-dev \
-          libboost-system-dev \
-          libboost-thread-dev \
-          libboost-atomic-dev \
-          libboost-chrono-dev \
-          libboost-container-dev \
-          libboost-context-dev \
-          libboost-contract-dev \
-          libboost-coroutine-dev \
-          libboost-date-time-dev \
-          libboost-fiber-dev \
-          libboost-filesystem-dev \
-          libboost-graph-parallel-dev \
-          libboost-log-dev \
-          libboost-regex-dev \
-          libboost-serialization-dev \
+          libboost1.83-dev \
+          libboost-program-options1.83-dev \
+          libboost-system1.83-dev \
+          libboost-thread1.83-dev \
+          libboost-atomic1.83-dev \
+          libboost-chrono1.83-dev \
+          libboost-container1.83-dev \
+          libboost-context1.83-dev \
+          libboost-contract1.83-dev \
+          libboost-coroutine1.83-dev \
+          libboost-date-time1.83-dev \
+          libboost-fiber1.83-dev \
+          libboost-filesystem1.83-dev \
+          libboost-graph-parallel1.83-dev \
+          libboost-log1.83-dev \
+          libboost-regex1.83-dev \
+          libboost-serialization1.83-dev \
           googletest \
           libgtest-dev \
           libhiredis0.14 \
@@ -214,30 +220,30 @@ jobs:
   timeoutInMinutes: 180
   pool: sonicso1ES-armhf
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-armhf:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)-armhf
 
   steps:
   - script: |
       set -ex
       sudo apt-get update
       sudo apt-get install -y \
-          libboost-dev \
-          libboost-program-options-dev \
-          libboost-system-dev \
-          libboost-thread-dev \
-          libboost-atomic-dev \
-          libboost-chrono-dev \
-          libboost-container-dev \
-          libboost-context-dev \
-          libboost-contract-dev \
-          libboost-coroutine-dev \
-          libboost-date-time-dev \
-          libboost-fiber-dev \
-          libboost-filesystem-dev \
-          libboost-graph-parallel-dev \
-          libboost-log-dev \
-          libboost-regex-dev \
-          libboost-serialization-dev \
+          libboost1.83-dev \
+          libboost-program-options1.83-dev \
+          libboost-system1.83-dev \
+          libboost-thread1.83-dev \
+          libboost-atomic1.83-dev \
+          libboost-chrono1.83-dev \
+          libboost-container1.83-dev \
+          libboost-context1.83-dev \
+          libboost-contract1.83-dev \
+          libboost-coroutine1.83-dev \
+          libboost-date-time1.83-dev \
+          libboost-fiber1.83-dev \
+          libboost-filesystem1.83-dev \
+          libboost-graph-parallel1.83-dev \
+          libboost-log1.83-dev \
+          libboost-regex1.83-dev \
+          libboost-serialization1.83-dev \
           googletest \
           libgtest-dev \
           libhiredis0.14 \


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

Please provide following information to help code review process a bit easier:
-->
### Description of PR
<!--
- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context. Where should reviewer start? background context?
- List any dependencies that are required for this change.
-->
A new slave naming convention is being used https://github.com/sonic-net/sonic-buildimage/pull/24922.
This PR is to update the docker slave name accordingly and switch to using libboost1.83 to align with the docker environment.
Summary:
Fixes # (issue)

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

#### How did you verify/test it?

#### Any platform specific information?

### Documentation 
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->