### PR TITLE
Fix missing return in test function causing SIGILL with GCC 14

### DIFF
--- a/test/MuxManagerTest.cpp
+++ b/test/MuxManagerTest.cpp
@@ -115,7 +115,7 @@ bool MuxManagerTest::getIfUseWellKnownMac(std::string port)
     return muxPortPtr->mMuxPortConfig.getIfUseWellKnownMacActiveActive();
 }
 
-bool MuxManagerTest::setUseWellKnownMacActiveActive(bool use)
+void MuxManagerTest::setUseWellKnownMacActiveActive(bool use)
 {
     mMuxManagerPtr->setUseWellKnownMacActiveActive(use);
 }

--- a/test/MuxManagerTest.h
+++ b/test/MuxManagerTest.h
@@ -58,7 +58,7 @@ public:
     uint32_t getLinkWaitTimeout_msec(std::string port);
     uint32_t getOscillationInterval_sec(std::string port);
     bool getIfUseWellKnownMac(std::string port);
-    bool setUseWellKnownMacActiveActive(bool use);
+    void setUseWellKnownMacActiveActive(bool use);
     bool getIfUseToRMac(std::string port);
     bool getOscillationEnabled(std::string port);
     common::MuxPortConfig::LinkProberType getLinkProberType(const std::string &port);


### PR DESCRIPTION
## Description
`MuxManagerTest::setUseWellKnownMacActiveActive()` is declared as returning `bool` but has no return statement. This is undefined behavior in C++.

- **GCC 13 (bookworm):** Silently ignores the missing return
- **GCC 14 (trixie):** Inserts `ud2` (intentional illegal instruction) to trap the UB

This causes `MuxManagerTest.ServerMacActiveActiveBeforeLinkProberInit` to crash with **SIGILL (exit code 132)** when linkmgrd is built in a trixie environment.

## Root Cause
```cpp
// test/MuxManagerTest.cpp:118
bool MuxManagerTest::setUseWellKnownMacActiveActive(bool use)
{
    mMuxManagerPtr->setUseWellKnownMacActiveActive(use);
    // No return statement — UB!
}
```

The underlying `MuxManager::setUseWellKnownMacActiveActive()` returns `void`, so the test wrapper should too.

## Fix
Change return type from `bool` to `void` in both the declaration (.h) and definition (.cpp).

## How I tested
- Built linkmgrd test binary with `-g -O0` in trixie slave container
- Ran under GDB: crash at `ud2` instruction at function epilogue
- After fix: function no longer has missing return UB