### PR TITLE
[CI] Fix 202511 branch build: use branch-tagged images and pin boost 1.83

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,23 +39,23 @@ jobs:
     displayName: install .Net
   - script: |
       sudo apt-get install -y\
-          libboost-dev \
-          libboost-program-options-dev \
-          libboost-system-dev \
-          libboost-thread-dev \
-          libboost-atomic-dev \
-          libboost-chrono-dev \
-          libboost-container-dev \
-          libboost-context-dev \
-          libboost-contract-dev \
-          libboost-coroutine-dev \
-          libboost-date-time-dev \
-          libboost-fiber-dev \
-          libboost-filesystem-dev \
-          libboost-graph-parallel-dev \
-          libboost-log-dev \
-          libboost-regex-dev \
-          libboost-serialization-dev \
+          libboost1.74-dev \
+          libboost-program-options1.74-dev \
+          libboost-system1.74-dev \
+          libboost-thread1.74-dev \
+          libboost-atomic1.74-dev \
+          libboost-chrono1.74-dev \
+          libboost-container1.74-dev \
+          libboost-context1.74-dev \
+          libboost-contract1.74-dev \
+          libboost-coroutine1.74-dev \
+          libboost-date-time1.74-dev \
+          libboost-fiber1.74-dev \
+          libboost-filesystem1.74-dev \
+          libboost-graph-parallel1.74-dev \
+          libboost-log1.74-dev \
+          libboost-regex1.74-dev \
+          libboost-serialization1.74-dev \
           googletest \
           libgtest-dev \
           libgmock-dev \
@@ -136,23 +136,23 @@ jobs:
       set -ex
       sudo apt-get update
       sudo apt-get install -y\
-          libboost-dev \
-          libboost-program-options-dev \
-          libboost-system-dev \
-          libboost-thread-dev \
-          libboost-atomic-dev \
-          libboost-chrono-dev \
-          libboost-container-dev \
-          libboost-context-dev \
-          libboost-contract-dev \
-          libboost-coroutine-dev \
-          libboost-date-time-dev \
-          libboost-fiber-dev \
-          libboost-filesystem-dev \
-          libboost-graph-parallel-dev \
-          libboost-log-dev \
-          libboost-regex-dev \
-          libboost-serialization-dev \
+          libboost1.74-dev \
+          libboost-program-options1.74-dev \
+          libboost-system1.74-dev \
+          libboost-thread1.74-dev \
+          libboost-atomic1.74-dev \
+          libboost-chrono1.74-dev \
+          libboost-container1.74-dev \
+          libboost-context1.74-dev \
+          libboost-contract1.74-dev \
+          libboost-coroutine1.74-dev \
+          libboost-date-time1.74-dev \
+          libboost-fiber1.74-dev \
+          libboost-filesystem1.74-dev \
+          libboost-graph-parallel1.74-dev \
+          libboost-log1.74-dev \
+          libboost-regex1.74-dev \
+          libboost-serialization1.74-dev \
           googletest \
           libgtest-dev \
           libhiredis0.14 \
@@ -227,23 +227,23 @@ jobs:
       set -ex
       sudo apt-get update
       sudo apt-get install -y \
-          libboost-dev \
-          libboost-program-options-dev \
-          libboost-system-dev \
-          libboost-thread-dev \
-          libboost-atomic-dev \
-          libboost-chrono-dev \
-          libboost-container-dev \
-          libboost-context-dev \
-          libboost-contract-dev \
-          libboost-coroutine-dev \
-          libboost-date-time-dev \
-          libboost-fiber-dev \
-          libboost-filesystem-dev \
-          libboost-graph-parallel-dev \
-          libboost-log-dev \
-          libboost-regex-dev \
-          libboost-serialization-dev \
+          libboost1.74-dev \
+          libboost-program-options1.74-dev \
+          libboost-system1.74-dev \
+          libboost-thread1.74-dev \
+          libboost-atomic1.74-dev \
+          libboost-chrono1.74-dev \
+          libboost-container1.74-dev \
+          libboost-context1.74-dev \
+          libboost-contract1.74-dev \
+          libboost-coroutine1.74-dev \
+          libboost-date-time1.74-dev \
+          libboost-fiber1.74-dev \
+          libboost-filesystem1.74-dev \
+          libboost-graph-parallel1.74-dev \
+          libboost-log1.74-dev \
+          libboost-regex1.74-dev \
+          libboost-serialization1.74-dev \
           googletest \
           libgtest-dev \
           libhiredis0.14 \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,12 @@ trigger:
     include:
       - "*"
 
+variables:
+  - name: BUILD_BRANCH
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      value: $(System.PullRequest.TargetBranch)
+    ${{ else }}:
+      value: $(Build.SourceBranchName)
 
 jobs:
 - job:
@@ -20,7 +26,7 @@ jobs:
     vmImage: 'ubuntu-22.04'
 
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)
 
   steps:
   - script: |
@@ -123,7 +129,7 @@ jobs:
   timeoutInMinutes: 180
   pool: sonicso1ES-arm64
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-arm64:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)-arm64
 
   steps:
   - script: |
@@ -214,7 +220,7 @@ jobs:
   timeoutInMinutes: 180
   pool: sonicso1ES-armhf
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-armhf:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)-armhf
 
   steps:
   - script: |


### PR DESCRIPTION
## Problem
The 202511 branch `azure-pipelines.yml` has:
1. Hardcoded `:latest` image tags instead of `$(BUILD_BRANCH)` — the `:latest` sonic-slave-bookworm image has boost 1.74 pre-installed
2. Unversioned `libboost-dev` packages which now resolve to 1.83 on bookworm repos, conflicting with pre-installed 1.74

## Fix
- Change image tags from `:latest` to `:$(BUILD_BRANCH)` for all three jobs (amd64, arm64, armhf)
- Pin all boost packages to version 1.83 (matching master): `libboost1.83-dev`, `libboost-program-options1.83-dev`, etc.

Signed-off-by: Ying Xie <yxieca@microsoft.com>