### PR TITLE
[202511] Cherry-pick #324 (boost 1.83) and #332 (CodeQL fix)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,11 +29,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2.1.29
+      uses: github/codeql-action/init@v3
       with:
         config-file: ./.github/codeql/codeql-config.yml
         languages: ${{ matrix.language }}
@@ -76,7 +76,7 @@ jobs:
         git clone https://github.com/sonic-net/sonic-swss-common
         pushd sonic-swss-common
         ./autogen.sh
-        git checkout $GITHUB_BASE_REF
+        git checkout ${GITHUB_BASE_REF:-master}
         git reset HEAD --hard
         dpkg-buildpackage -rfakeroot -us -uc -b -Pnoyangmod,nopython2 -j$(nproc)
         popd
@@ -84,6 +84,47 @@ jobs:
         dpkg-deb -x libswsscommon-dev_${SWSSCOMMON_VER}_amd64.deb $(dirname $GITHUB_WORKSPACE)
       env:
         SWSSCOMMON_VER: "1.0.0"
+
+    - name: generate-cfg-schema
+      run: |
+        # cfg_schema.h is normally auto-generated from YANG models by gen_cfg_schema.py
+        # during swss-common build. With -Pnoyangmod, only an empty stub is produced.
+        # Generate the CFG_* macros needed by linkmgrd from the YANG model files directly.
+        git clone --depth=1 https://github.com/sonic-net/sonic-buildimage /tmp/sonic-buildimage
+        python3 - /tmp/sonic-buildimage/src/sonic-yang-models/yang-models <<'PYEOF'
+        import sys, os, re, glob
+
+        yang_dir = sys.argv[1]
+        macros = {}
+        # Extract container names from YANG models — these become CFG_*_TABLE_NAME macros
+        for yang_file in glob.glob(os.path.join(yang_dir, '*.yang')):
+            with open(yang_file) as f:
+                content = f.read()
+            # Match top-level container names under sonic-* modules
+            for m in re.finditer(r'container\s+(\S+)\s*\{', content):
+                name = m.group(1)
+                # Convert to macro: e.g. MUX_CABLE -> CFG_MUX_CABLE_TABLE_NAME
+                macro_name = 'CFG_{}_TABLE_NAME'.format(name.replace('-', '_').upper())
+                macros[macro_name] = name.replace('_', '-') if '_' in name else name
+
+        # Write cfg_schema.h
+        schema_dir = os.path.join(os.environ.get('GITHUB_WORKSPACE', '.'), '..', 'usr', 'include', 'swss')
+        os.makedirs(schema_dir, exist_ok=True)
+        outpath = os.path.join(schema_dir, 'cfg_schema.h')
+
+        # Also patch the existing schema.h to include cfg_schema.h if not already
+        schema_h = os.path.join(schema_dir, 'schema.h')
+
+        with open(outpath, 'w') as f:
+            f.write('#ifndef CFG_SCHEMA_H\n#define CFG_SCHEMA_H\n\n')
+            f.write('#ifdef __cplusplus\nnamespace swss {\n#endif\n\n')
+            for macro in sorted(macros):
+                f.write('#define {} "{}"\n'.format(macro, macros[macro]))
+            f.write('\n#ifdef __cplusplus\n}\n#endif\n#endif\n')
+
+        print(f'Generated {len(macros)} CFG_* macros in {outpath}')
+        PYEOF
+        rm -rf /tmp/sonic-buildimage
 
     - name: build
       run: |
@@ -94,6 +135,6 @@ jobs:
         make all INCLUDES="-L$(dirname $GITHUB_WORKSPACE)/usr/lib/x86_64-linux-gnu -I$(dirname $GITHUB_WORKSPACE)/usr/include"
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2.1.29
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,12 @@ trigger:
     include:
       - "*"
 
+variables:
+  - name: BUILD_BRANCH
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      value: $(System.PullRequest.TargetBranch)
+    ${{ else }}:
+      value: $(Build.SourceBranchName)
 
 jobs:
 - job:
@@ -20,7 +26,7 @@ jobs:
     vmImage: 'ubuntu-22.04'
 
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)
 
   steps:
   - script: |
@@ -33,23 +39,23 @@ jobs:
     displayName: install .Net
   - script: |
       sudo apt-get install -y\
-          libboost-dev \
-          libboost-program-options-dev \
-          libboost-system-dev \
-          libboost-thread-dev \
-          libboost-atomic-dev \
-          libboost-chrono-dev \
-          libboost-container-dev \
-          libboost-context-dev \
-          libboost-contract-dev \
-          libboost-coroutine-dev \
-          libboost-date-time-dev \
-          libboost-fiber-dev \
-          libboost-filesystem-dev \
-          libboost-graph-parallel-dev \
-          libboost-log-dev \
-          libboost-regex-dev \
-          libboost-serialization-dev \
+          libboost1.83-dev \
+          libboost-program-options1.83-dev \
+          libboost-system1.83-dev \
+          libboost-thread1.83-dev \
+          libboost-atomic1.83-dev \
+          libboost-chrono1.83-dev \
+          libboost-container1.83-dev \
+          libboost-context1.83-dev \
+          libboost-contract1.83-dev \
+          libboost-coroutine1.83-dev \
+          libboost-date-time1.83-dev \
+          libboost-fiber1.83-dev \
+          libboost-filesystem1.83-dev \
+          libboost-graph-parallel1.83-dev \
+          libboost-log1.83-dev \
+          libboost-regex1.83-dev \
+          libboost-serialization1.83-dev \
           googletest \
           libgtest-dev \
           libgmock-dev \
@@ -123,30 +129,30 @@ jobs:
   timeoutInMinutes: 180
   pool: sonicso1ES-arm64
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-arm64:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)-arm64
 
   steps:
   - script: |
       set -ex
       sudo apt-get update
       sudo apt-get install -y\
-          libboost-dev \
-          libboost-program-options-dev \
-          libboost-system-dev \
-          libboost-thread-dev \
-          libboost-atomic-dev \
-          libboost-chrono-dev \
-          libboost-container-dev \
-          libboost-context-dev \
-          libboost-contract-dev \
-          libboost-coroutine-dev \
-          libboost-date-time-dev \
-          libboost-fiber-dev \
-          libboost-filesystem-dev \
-          libboost-graph-parallel-dev \
-          libboost-log-dev \
-          libboost-regex-dev \
-          libboost-serialization-dev \
+          libboost1.83-dev \
+          libboost-program-options1.83-dev \
+          libboost-system1.83-dev \
+          libboost-thread1.83-dev \
+          libboost-atomic1.83-dev \
+          libboost-chrono1.83-dev \
+          libboost-container1.83-dev \
+          libboost-context1.83-dev \
+          libboost-contract1.83-dev \
+          libboost-coroutine1.83-dev \
+          libboost-date-time1.83-dev \
+          libboost-fiber1.83-dev \
+          libboost-filesystem1.83-dev \
+          libboost-graph-parallel1.83-dev \
+          libboost-log1.83-dev \
+          libboost-regex1.83-dev \
+          libboost-serialization1.83-dev \
           googletest \
           libgtest-dev \
           libhiredis0.14 \
@@ -214,30 +220,30 @@ jobs:
   timeoutInMinutes: 180
   pool: sonicso1ES-armhf
   container:
-    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-armhf:latest
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:$(BUILD_BRANCH)-armhf
 
   steps:
   - script: |
       set -ex
       sudo apt-get update
       sudo apt-get install -y \
-          libboost-dev \
-          libboost-program-options-dev \
-          libboost-system-dev \
-          libboost-thread-dev \
-          libboost-atomic-dev \
-          libboost-chrono-dev \
-          libboost-container-dev \
-          libboost-context-dev \
-          libboost-contract-dev \
-          libboost-coroutine-dev \
-          libboost-date-time-dev \
-          libboost-fiber-dev \
-          libboost-filesystem-dev \
-          libboost-graph-parallel-dev \
-          libboost-log-dev \
-          libboost-regex-dev \
-          libboost-serialization-dev \
+          libboost1.83-dev \
+          libboost-program-options1.83-dev \
+          libboost-system1.83-dev \
+          libboost-thread1.83-dev \
+          libboost-atomic1.83-dev \
+          libboost-chrono1.83-dev \
+          libboost-container1.83-dev \
+          libboost-context1.83-dev \
+          libboost-contract1.83-dev \
+          libboost-coroutine1.83-dev \
+          libboost-date-time1.83-dev \
+          libboost-fiber1.83-dev \
+          libboost-filesystem1.83-dev \
+          libboost-graph-parallel1.83-dev \
+          libboost-log1.83-dev \
+          libboost-regex1.83-dev \
+          libboost-serialization1.83-dev \
           googletest \
           libgtest-dev \
           libhiredis0.14 \


### PR DESCRIPTION
Cherry-pick two master pipeline fixes to 202511 branch:

1. **#324** — update docker slave name and switch to using libboost1.83
   - Adds `BUILD_BRANCH` variable for branch-tagged container images
   - Pins all boost packages to 1.83 (matching sonic-slave-bookworm image)

2. **#332** — Fix CodeQL workflow: update actions, fix GITHUB_BASE_REF, add cfg_schema.h

These are needed to fix CI build failures on the 202511 branch (e.g. #333).

Signed-off-by: Ying Xie <ying.xie@microsoft.com>