### PR TITLE
[202511] Simplify CodeQL: match sonic-swss pattern

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -76,55 +76,12 @@ jobs:
         git clone https://github.com/sonic-net/sonic-swss-common
         pushd sonic-swss-common
         ./autogen.sh
-        git checkout ${GITHUB_BASE_REF:-master}
-        git reset HEAD --hard
         dpkg-buildpackage -rfakeroot -us -uc -b -Pnoyangmod,nopython2 -j$(nproc)
         popd
         dpkg-deb -x libswsscommon_${SWSSCOMMON_VER}_amd64.deb $(dirname $GITHUB_WORKSPACE)
         dpkg-deb -x libswsscommon-dev_${SWSSCOMMON_VER}_amd64.deb $(dirname $GITHUB_WORKSPACE)
       env:
         SWSSCOMMON_VER: "1.0.0"
-
-    - name: generate-cfg-schema
-      run: |
-        # cfg_schema.h is normally auto-generated from YANG models by gen_cfg_schema.py
-        # during swss-common build. With -Pnoyangmod, only an empty stub is produced.
-        # Generate the CFG_* macros needed by linkmgrd from the YANG model files directly.
-        git clone --depth=1 https://github.com/sonic-net/sonic-buildimage /tmp/sonic-buildimage
-        python3 - /tmp/sonic-buildimage/src/sonic-yang-models/yang-models <<'PYEOF'
-        import sys, os, re, glob
-
-        yang_dir = sys.argv[1]
-        macros = {}
-        # Extract container names from YANG models — these become CFG_*_TABLE_NAME macros
-        for yang_file in glob.glob(os.path.join(yang_dir, '*.yang')):
-            with open(yang_file) as f:
-                content = f.read()
-            # Match top-level container names under sonic-* modules
-            for m in re.finditer(r'container\s+(\S+)\s*\{', content):
-                name = m.group(1)
-                # Convert to macro: e.g. MUX_CABLE -> CFG_MUX_CABLE_TABLE_NAME
-                macro_name = 'CFG_{}_TABLE_NAME'.format(name.replace('-', '_').upper())
-                macros[macro_name] = name.replace('_', '-') if '_' in name else name
-
-        # Write cfg_schema.h
-        schema_dir = os.path.join(os.environ.get('GITHUB_WORKSPACE', '.'), '..', 'usr', 'include', 'swss')
-        os.makedirs(schema_dir, exist_ok=True)
-        outpath = os.path.join(schema_dir, 'cfg_schema.h')
-
-        # Also patch the existing schema.h to include cfg_schema.h if not already
-        schema_h = os.path.join(schema_dir, 'schema.h')
-
-        with open(outpath, 'w') as f:
-            f.write('#ifndef CFG_SCHEMA_H\n#define CFG_SCHEMA_H\n\n')
-            f.write('#ifdef __cplusplus\nnamespace swss {\n#endif\n\n')
-            for macro in sorted(macros):
-                f.write('#define {} "{}"\n'.format(macro, macros[macro]))
-            f.write('\n#ifdef __cplusplus\n}\n#endif\n#endif\n')
-
-        print(f'Generated {len(macros)} CFG_* macros in {outpath}')
-        PYEOF
-        rm -rf /tmp/sonic-buildimage
 
     - name: build
       run: |


### PR DESCRIPTION
### Description of PR

Summary: [202511] Simplify CodeQL workflow to match [sonic-swss's pattern](https://github.com/sonic-net/sonic-swss/blob/master/.github/workflows/codeql-analysis.yml).

Remove `git checkout ${GITHUB_BASE_REF:-master}` + `git reset HEAD --hard` from the `build-swss-common` step, and remove the `generate-cfg-schema` step. These were cherry-picked from #332 via #336 but are unnecessary — sonic-swss builds swss-common by simply cloning and building from the default branch.

### Type of change

- [x] Bug fix

### Approach
#### What is the motivation for this PR?

#336 cherry-picked #332's CodeQL fix to 202511, including the over-engineered `generate-cfg-schema` step and `GITHUB_BASE_REF` checkout. This simplifies it to match the sonic-swss pattern.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

1. Removed `git checkout` and `git reset` lines from `build-swss-common` step
2. Removed the entire `generate-cfg-schema` step

#### How did you verify/test it?

CI will verify — CodeQL workflow should pass without these steps, same as sonic-swss.

#### Any platform specific information?

N/A

### Documentation

N/A
