### PR TITLE
azure-pipelines: migrate libyang1 deb install to libyang3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -153,6 +153,10 @@ jobs:
         sed -i "/JOBS := \$(subst -j,,\$(JOB_FLAG))/a JOBS := 1" Makefile
         sed -i -e "s/ -flto//g" Makefile
         sed -i '/-include objects.mk/a LIBS := -L'"$(dirname $GITHUB_WORKSPACE)"'/usr/lib/x86_64-linux-gnu \$(LIBS)' Makefile
+        # libswsscommon.so pulls in libyang.so.3 as an indirect dependency. ld
+        # does not search -L paths for indirect deps, only -rpath-link and
+        # LD_LIBRARY_PATH, so point it at the staged libyang3 in the prefix.
+        export LD_LIBRARY_PATH="$(dirname $GITHUB_WORKSPACE)/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
         make all INCLUDES="-L$(dirname $GITHUB_WORKSPACE)/usr/lib/x86_64-linux-gnu -I$(dirname $GITHUB_WORKSPACE)/usr/include"
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,7 +50,6 @@ jobs:
             libnl-genl-3-dev \
             libnl-route-3-dev \
             libnl-nf-3-dev \
-            libyang-dev \
             libzmq3-dev \
             libzmq5 \
             swig3.0 \
@@ -131,7 +130,18 @@ jobs:
           exit 0
         fi
 
-        rm -rf /tmp/swss-common /tmp/swss-common.zip
+        # libswsscommon is built against libyang3 (libyang.so.3); the distro
+        # apt libyang on this runner is libyang1, so the link would fail with
+        # "libyang.so.3 ... not found". Stage the libyang3 debs into the same
+        # prefix as swss-common. The sonic-build artifacts REST API requires an
+        # exact filename (wildcards do not resolve), so fetch the bookworm debs
+        # directory as a zip and extract just the libyang3 debs with a glob to
+        # stay version-independent across libyang3 bumps.
+        curl -sL -o /tmp/bookworm-debs.zip "https://sonic-build.azurewebsites.net/api/sonic/artifacts?branchName=master&platform=vs&target=target/debs/bookworm&format=zip"
+        unzip -j -o /tmp/bookworm-debs.zip '*/libyang3_*.deb' '*/libyang-dev_*.deb' -d /tmp/libyang
+        for d in /tmp/libyang/*.deb; do dpkg-deb -x "$d" $(dirname $GITHUB_WORKSPACE); done
+
+        rm -rf /tmp/swss-common /tmp/swss-common.zip /tmp/libyang /tmp/bookworm-debs.zip
         echo "installed=true" >> "$GITHUB_OUTPUT"
       env:
         SWSSCOMMON_VER: "1.0.0"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib
       patterns: |
-        target/debs/bookworm/libyang_*.deb
+        target/debs/bookworm/libyang3_*.deb
     displayName: "Download libyang from common lib"
   - script: |
       set -ex
@@ -184,7 +184,7 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib.arm64
       patterns: |
-        target/debs/bookworm/libyang_*.deb
+        target/debs/bookworm/libyang3_*.deb
     displayName: "Download libyang from common lib"
   - script: |
       set -ex
@@ -275,7 +275,7 @@ jobs:
       path: $(Build.ArtifactStagingDirectory)/download
       artifact: common-lib.armhf
       patterns: |
-        target/debs/bookworm/libyang_*.deb
+        target/debs/bookworm/libyang3_*.deb
     displayName: "Download libyang from common lib"
   - script: |
       set -ex


### PR DESCRIPTION
### Description of PR

Summary:
`sonic-buildimage` no longer builds the legacy libyang1 deb (`libyang_1.0.73`); it now builds only libyang3. Updated the three `DownloadPipelineArtifact` filter patterns in `azure-pipelines.yml` from `target/debs/bookworm/libyang_*.deb` to `target/debs/bookworm/libyang3_*.deb` so CI pulls the libyang3 deb. The install steps use a generic `dpkg -i $(find ./download -name *.deb)`, so no install-command change was needed.

Part of sonic-net/sonic-buildimage#22385.

Fixes # (N/A — tracked under sonic-net/sonic-buildimage#22385)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Doc/Design
- [ ] Unit test

### Approach
#### What is the motivation for this PR?

Once libyang1 is removed from `sonic-buildimage`, the old `libyang_*.deb` download filter matches nothing and CI fails to install libyang.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How did you do it?

Replaced `libyang_*.deb` with `libyang3_*.deb` in all three artifact-download filters (amd64 / arm64 / armhf common-lib).

#### How did you verify/test it?

Re-grepped for libyang1 references — none remain except the CodeQL/LGTM distro-apt `libyang-dev` entries (not sourced from `sonic-buildimage` artifacts), which were intentionally left unchanged.

#### Any platform specific information?

None.

### Documentation

No documentation changes required.
