### PR TITLE
[github]: Add backport test evidence sections

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,53 @@ Fixes # (issue)
 - [ ] Doc/Design
 - [ ] Unit test
 
+### Back port request
+<!--
+Only check a release or feature branch when the PR links a GitHub issue or ADO
+work item above. The linked tracker should explain the failure in detail,
+including whether it is a day-one issue or a regression, the affected
+branch/image/platform/test, and why this branch needs the fix. Backport or
+cherry-pick requests without a linked issue/work item may not be favored.
+
+If you request a backport/cherry-pick, provide both:
+1. A GitHub issue or Microsoft ADO work item tracking the change.
+2. Test evidence from the target branch(es) requested below.
+-->
+- [ ] 202305
+- [ ] 202311
+- [ ] 202405
+- [ ] 202411
+- [ ] 202505
+- [ ] 202511
+- [ ] 202605
+
+Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
+Failure type: <!-- day-one issue / regression / other -->
+
+### Tested branch
+<!--
+Select each branch where the change was tested. If you request a
+backport/cherry-pick, select the base branch and the tested target release
+branch(es).
+-->
+- [ ] master
+- [ ] 202305
+- [ ] 202311
+- [ ] 202405
+- [ ] 202411
+- [ ] 202505
+- [ ] 202511
+- [ ] 202605
+- [ ] N/A
+
+### Test result
+<!--
+Provide the tested image version and test evidence for each selected branch.
+For example:
+- master: 20260716.01 - <test result or link>
+- 202605: 20260531.42 - <test result or link>
+-->
+
 ### Approach
 #### What is the motivation for this PR?
 
@@ -36,6 +83,10 @@ Fixes # (issue)
 #### How did you do it?
 
 #### How did you verify/test it?
+<!--
+Summarize the overall validation here. For a backport/cherry-pick request,
+provide branch-specific image versions and evidence in the Test result section.
+-->
 
 #### Any platform specific information?
 


### PR DESCRIPTION
### Description of PR
Summary:
Aligns the sonic-linkmgrd PR template with the backport/cherry-pick validation
structure introduced in sonic-net/sonic-buildimage#28464 and
sonic-net/sonic-mgmt#26279. Adds a "Back port request" section (requiring a
linked GitHub issue or Microsoft ADO work item plus target-branch test
evidence for any backport/cherry-pick), a "Tested branch" section, and a
separate "Test result" section, using the same active release branch set
(202305, 202311, 202405, 202411, 202505, 202511, 202605). This is a
documentation/framework-only change to `.github/pull_request_template.md`;
no source, build, or automation code is touched.

Fixes # (issue)
N/A - documentation/framework change, not tied to a bug.

### Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Doc/Design
- [ ] Unit test

### Back port request
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A - no backport requested
Failure type: N/A

### Tested branch
- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605
- [x] N/A

### Test result
N/A - this PR only changes the Markdown PR template text/structure; there is
no image build or runtime test surface to validate. Validation performed was
template-only: rendered the Markdown to confirm section order, checkbox
syntax, and hidden-comment placement, and ran `git diff --check` to confirm
no whitespace errors.

### Approach
#### What is the motivation for this PR?
sonic-buildimage and sonic-mgmt recently standardized their PR templates to
require an explicit tracking issue/work item and target-branch test evidence
before a backport/cherry-pick is honored. This PR brings sonic-linkmgrd's
template in line with that same structure so backport requests across the
three repos are validated consistently.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How did you do it?
Inserted a new "Back port request" section immediately before "### Approach"
in `.github/pull_request_template.md`, with hidden Markdown comments
explaining that a backport/cherry-pick request requires a linked GitHub issue
or Microsoft ADO work item describing the failure, plus test evidence from
the target branch(es). Added unchecked checkboxes for the currently active
release branches (202305, 202311, 202405, 202411, 202505, 202511, 202605) and
visible "Tracking issue/work item" and "Failure type" fields. Added a
"### Tested branch" section (master + the same seven release branches + N/A)
and a separate "### Test result" section with examples for master and
202605. Updated the hidden comment under "How did you verify/test it?" to
point branch-specific evidence to the new Test result section, while
preserving the existing visible section. All other sections and wording were
preserved unchanged.

#### How did you verify/test it?
Rendered the updated template locally to confirm heading hierarchy, checkbox
list rendering, and hidden-comment (non-visible) placement match the
reference structure from sonic-buildimage#28464 / sonic-mgmt#26279. Ran
`git diff --check` against the change - no whitespace/trailing-space errors.
No backport of this change itself is requested (template-only, applies going
forward on master).

#### Any platform specific information?
N/A - this is a GitHub Markdown template file, not platform-specific code.

### Documentation
This change *is* the documentation update (PR template itself). No
additional wiki updates are required.

---
Companion to sonic-net/sonic-buildimage#28464 and sonic-net/sonic-mgmt#26279.
